### PR TITLE
Kern value as float

### DIFF
--- a/Lib/fontParts/objects/base/kerning.py
+++ b/Lib/fontParts/objects/base/kerning.py
@@ -127,8 +127,8 @@ class BaseKerning(BaseDict):
     def remove(self, key):
         del self[key]
 
-    def asDict(self):
+    def asDict(self, returnIntegers=True):
         d = {}
         for k, v in self.items():
-            d[k] = v
+            d[k] = v if not returnIntegers else int(round(v))
         return d

--- a/Lib/fontParts/objects/base/validators.py
+++ b/Lib/fontParts/objects/base/validators.py
@@ -103,11 +103,11 @@ def validateKerningKey(value):
 def validateKerningValue(value):
     """Validates kerning value
     
-    - value must be a int.
+    - value must be a int or a float.
     - Returned value is the same as input value.
     """
-    if not isinstance(value, int):
-        raise FontPartsError("Kerning value must be a int, not %s." % type(value).__name__)
+    if not isinstance(value, (int, float)):
+        raise FontPartsError("Kerning value must be a int or a float, not %s." % type(value).__name__)
     return value
 
 # ------


### PR DESCRIPTION
- Change signature of `BaseKerning.asDict(self)` to `BaseKerning.asDict(self, returnIntegers=True)` as in robofab (https://github.com/robofab-developers/robofab/blob/master/Lib/robofab/objects/objectsBase.py#L3404)
- Change validation of kern value to allow float (http://unifiedfontobject.org/versions/ufo3/kerning.plist/)