### PR TITLE
Changed instead of Update

### DIFF
--- a/Lib/fontParts/base/base.py
+++ b/Lib/fontParts/base/base.py
@@ -99,13 +99,13 @@ class BaseObject(object):
     # Environment Fallbacks
     # ---------------------
 
-    def update(self, *args, **kwargs):
+    def changed(self, *args, **kwargs):
         """
         Tell the environment that something has changed in
         the object. The behavior of this method will vary
         from environment to environment.
 
-            >>> obj.update()
+            >>> obj.changed()
         """
 
     def naked(self):

--- a/documentation/source/environments/index.rst
+++ b/documentation/source/environments/index.rst
@@ -153,11 +153,11 @@ Each of these require their own specific environment overrides, but the general 
 
         # Environment updating.
         # If the environment requires the scripter to manually
-        # notify the environment that the object has been updated,
-        # the subclass must implement the update method. Please
+        # notify the environment that the object has been changed,
+        # the subclass must implement the changed method. Please
         # try to avoid requiring this.
 
-        def update(self):
+        def changed(self):
             myEnv.goUpdateYourself()
 
         # Wrapped objects.

--- a/documentation/source/objects/anchor.rst
+++ b/documentation/source/objects/anchor.rst
@@ -61,7 +61,7 @@ Environment
 ===========
 
 * :attr:`~BaseAnchor.naked` Get the environment's native anchor object.
-* :attr:`~BaseAnchor.update` Inform the environment to update the anchor.
+* :attr:`~BaseAnchor.changed` Inform the environment to update the anchor.
 
 
 *********
@@ -87,4 +87,4 @@ Reference
 	.. automethod:: scaleBy
 	.. automethod:: skewBy
 	.. automethod:: transformBy
-	.. automethod:: update
+	.. automethod:: changed

--- a/documentation/source/objects/bpoint.rst
+++ b/documentation/source/objects/bpoint.rst
@@ -45,7 +45,7 @@ Normalization
 Environment
 ===========
 * :meth:`~BaseBPoint.naked` (add general description)
-* :meth:`~BaseBPoint.update` (add general description)
+* :meth:`~BaseBPoint.changed` (add general description)
 
 *********
 Reference
@@ -69,4 +69,4 @@ Reference
 	.. automethod:: BaseBPoint.scaleBy
 	.. automethod:: BaseBPoint.skewBy
 	.. automethod:: BaseBPoint.transformBy
-	.. automethod:: BaseBPoint.update
+	.. automethod:: BaseBPoint.changed

--- a/documentation/source/objects/component.rst
+++ b/documentation/source/objects/component.rst
@@ -57,7 +57,7 @@ Normalization
 Environment
 ===========
 * :meth:`~BaseComponent.naked` (add general description)
-* :meth:`~BaseComponent.update` (add general description)
+* :meth:`~BaseComponent.changed` (add general description)
 
 *********
 Reference
@@ -87,4 +87,4 @@ Reference
 	.. automethod:: BaseComponent.scaleBy
 	.. automethod:: BaseComponent.skewBy
 	.. automethod:: BaseComponent.transformBy
-	.. automethod:: BaseComponent.update
+	.. automethod:: BaseComponent.changed

--- a/documentation/source/objects/contour.rst
+++ b/documentation/source/objects/contour.rst
@@ -79,7 +79,7 @@ Normalization
 Environment
 ===========
 * :meth:`~BaseContour.naked` (add general description)
-* :meth:`~BaseContour.update` (add general description)
+* :meth:`~BaseContour.changed` (add general description)
 
 
 *********
@@ -123,4 +123,4 @@ Reference
 	.. automethod:: BaseContour.setStartSegment
 	.. automethod:: BaseContour.skewBy
 	.. automethod:: BaseContour.transformBy
-	.. automethod:: BaseContour.update
+	.. automethod:: BaseContour.changed

--- a/documentation/source/objects/font.rst
+++ b/documentation/source/objects/font.rst
@@ -95,7 +95,7 @@ Environment
 ===========
 
 * :meth:`~BaseFont.naked` Get the environment's native font object.
-* :meth:`~BaseFont.update` Inform the environment to update the font.
+* :meth:`~BaseFont.changed` Inform the environment to update the font.
 
 
 *********
@@ -138,4 +138,4 @@ Reference
 	.. automethod:: BaseFont.removeLayer
 	.. automethod:: BaseFont.round
 	.. automethod:: BaseFont.save
-	.. automethod:: BaseFont.update
+	.. automethod:: BaseFont.changed

--- a/documentation/source/objects/glyph.rst
+++ b/documentation/source/objects/glyph.rst
@@ -136,7 +136,7 @@ Normalization
 Environment
 ===========
 * :meth:`~BaseGlyph.naked` (add general description)
-* :meth:`~BaseGlyph.update` (add general description)
+* :meth:`~BaseGlyph.changed` (add general description)
 
 *********
 Reference
@@ -206,4 +206,4 @@ Reference
 	.. automethod:: BaseGlyph.scaleBy
 	.. automethod:: BaseGlyph.skewBy
 	.. automethod:: BaseGlyph.transformBy
-	.. automethod:: BaseGlyph.update
+	.. automethod:: BaseGlyph.changed

--- a/documentation/source/objects/groups.rst
+++ b/documentation/source/objects/groups.rst
@@ -81,7 +81,7 @@ Queries
 Environment
 ===========
 * :meth:`~BaseGroups.naked` Get the environment's native Groups object.
-* :meth:`~BaseGroups.update` Inform the environment to update the Groups.
+* :meth:`~BaseGroups.changed` Inform the environment to update the Groups.
 
 
 *********
@@ -106,5 +106,5 @@ Reference
     .. automethod:: BaseGroups.naked
     .. automethod:: BaseGroups.pop
     .. automethod:: BaseGroups.update
-    .. automethod:: BaseGroups.update
     .. automethod:: BaseGroups.values
+    .. automethod:: BaseGroups.changed

--- a/documentation/source/objects/guideline.rst
+++ b/documentation/source/objects/guideline.rst
@@ -55,7 +55,7 @@ Normalization
 Environment
 ===========
 * :meth:`~BaseGuideline.naked` Get the environment's native guideline object.
-* :meth:`~BaseGuideline.update` Inform the environment to update the anchor.
+* :meth:`~BaseGuideline.changed` Inform the environment to update the anchor.
 
 
 *********
@@ -82,4 +82,4 @@ Reference
 	.. automethod:: BaseGuideline.scaleBy
 	.. automethod:: BaseGuideline.skewBy
 	.. automethod:: BaseGuideline.transformBy
-	.. automethod:: BaseGuideline.update
+	.. automethod:: BaseGuideline.changed

--- a/documentation/source/objects/image.rst
+++ b/documentation/source/objects/image.rst
@@ -42,7 +42,7 @@ Normalization
 Environment
 ===========
 * :meth:`~BaseImage.naked` (add general description)
-* :meth:`~BaseImage.update` (add general description)
+* :meth:`~BaseImage.changed` (add general description)
 
 
 *********
@@ -67,4 +67,4 @@ Reference
 	.. automethod:: BaseImage.scaleBy
 	.. automethod:: BaseImage.skewBy
 	.. automethod:: BaseImage.transformBy
-	.. automethod:: BaseImage.update
+	.. automethod:: BaseImage.changed

--- a/documentation/source/objects/info.rst
+++ b/documentation/source/objects/info.rst
@@ -28,7 +28,7 @@ Normalization
 Environment
 ===========
 * :meth:`~BaseInfo.naked` (add general description)
-* :meth:`~BaseInfo.update` (add general description)
+* :meth:`~BaseInfo.changed` (add general description)
 
 
 *********
@@ -42,4 +42,4 @@ Reference
 	.. automethod:: BaseInfo.interpolate
 	.. automethod:: BaseInfo.naked
 	.. automethod:: BaseInfo.round
-	.. automethod:: BaseInfo.update
+	.. automethod:: BaseInfo.changed

--- a/documentation/source/objects/kerning.rst
+++ b/documentation/source/objects/kerning.rst
@@ -48,7 +48,7 @@ Normalization
 Environment
 ===========
 * :meth:`~BaseKerning.naked` (add general description)
-* :meth:`~BaseKerning.update` (add general description)
+* :meth:`~BaseKerning.changed` (add general description)
 
 
 *********
@@ -72,8 +72,8 @@ Reference
 	.. automethod:: BaseKerning.keys
 	.. automethod:: BaseKerning.naked
 	.. automethod:: BaseKerning.pop
-	.. automethod:: BaseKerning.round	
+	.. automethod:: BaseKerning.round
 	.. automethod:: BaseKerning.scaleBy
 	.. automethod:: BaseKerning.update
-	.. automethod:: BaseKerning.update
 	.. automethod:: BaseKerning.values
+	.. automethod:: BaseKerning.changed

--- a/documentation/source/objects/layer.rst
+++ b/documentation/source/objects/layer.rst
@@ -58,7 +58,7 @@ Normalization
 Environment
 ===========
 * :meth:`~BaseLayer.naked` Get the environment’s native layer object.
-* :meth:`~BaseLayer.update` Inform the environment to update the layer.
+* :meth:`~BaseLayer.changed` Inform the environment to update the layer.
 
 *********
 Reference
@@ -84,4 +84,4 @@ Reference
 	.. automethod:: BaseLayer.newGlyph
 	.. automethod:: BaseLayer.removeGlyph
 	.. automethod:: BaseLayer.round
-	.. automethod:: BaseLayer.update
+	.. automethod:: BaseLayer.changed

--- a/documentation/source/objects/lib.rst
+++ b/documentation/source/objects/lib.rst
@@ -37,7 +37,7 @@ Dictionary
 Environment
 ===========
 * :meth:`~BaseLib.naked` (add general description)
-* :meth:`~BaseLib.update` (add general description)
+* :meth:`~BaseLib.changed` (add general description)
 
 
 *********
@@ -63,4 +63,4 @@ Reference
 	.. automethod:: BaseLib.update
 	.. automethod:: BaseLib.clear
 	.. automethod:: BaseLib.naked
-	.. automethod:: BaseLib.update
+	.. automethod:: BaseLib.changed

--- a/documentation/source/objects/point.rst
+++ b/documentation/source/objects/point.rst
@@ -60,7 +60,7 @@ Normalization
 Environment
 ===========
 * :meth:`~BasePoint.naked` Get the environment's native point object.
-* :meth:`~BasePoint.update` Inform the environment to update the point.
+* :meth:`~BasePoint.changed` Inform the environment to update the point.
 
 
 *********
@@ -88,4 +88,4 @@ Reference
 	.. automethod:: BasePoint.scaleBy
 	.. automethod:: BasePoint.skewBy
 	.. automethod:: BasePoint.transformBy
-	.. automethod:: BasePoint.update
+	.. automethod:: BasePoint.changed

--- a/documentation/source/objects/segment.rst
+++ b/documentation/source/objects/segment.rst
@@ -46,7 +46,7 @@ Normalization
 Environment
 ===========
 * :meth:`~BaseSegment.naked` (add general description)
-* :meth:`~BaseSegment.update` (add general description)
+* :meth:`~BaseSegment.changed` (add general description)
 
 
 *********
@@ -72,4 +72,4 @@ Reference
 	.. automethod:: BaseSegment.scaleBy
 	.. automethod:: BaseSegment.skewBy
 	.. automethod:: BaseSegment.transformBy
-	.. automethod:: BaseSegment.update
+	.. automethod:: BaseSegment.changed


### PR DESCRIPTION
BaseDict has an update method to update the dictionary information. This will conflict with the generic update method, used (well, hopefully not) when an environment needs to be told to update an object. @typemytype noted that RoboFab used both "update" and "changed" to do this, and "changed" seems to be a better method name, so this branch switches the generic update to changed, leaving update as a method of BaseDict.
