### PR TITLE
[docs] adding autosummary extension, restructuring doc pages

### DIFF
--- a/documentation/source/conf.py
+++ b/documentation/source/conf.py
@@ -55,7 +55,7 @@ except ImportError:
 # https://github.com/sphinx-doc/sphinx/issues/1254
 #
 from fontParts.base.base import dynamicProperty
-dynamicProperty.__get__ = lambda self, *args, **kwargs: self            
+dynamicProperty.__get__ = lambda self, *args, **kwargs: self
 #
 # /MonkeyPatch
 # ------------
@@ -79,6 +79,7 @@ extensions = [
     'sphinx.ext.coverage',
     'sphinx.ext.ifconfig',
     'sphinx.ext.viewcode',
+    'sphinx.ext.autosummary',
 ]
 
 autodoc_member_order = 'bysource'

--- a/documentation/source/environments/objects/normalizers.rst
+++ b/documentation/source/environments/objects/normalizers.rst
@@ -1,9 +1,9 @@
 .. highlight:: python
 .. module:: fontParts.base.normalizers
 
-##########
+###########
 Normalizers
-##########
+###########
 
 .. autofunction:: normalizeFileFormatVersion
 

--- a/documentation/source/index.rst
+++ b/documentation/source/index.rst
@@ -12,7 +12,7 @@ Designers
 =========
 
 .. toctree::
-   :maxdepth: 2
+   :maxdepth: 3
 
    gettingstarted/index
    objects/index

--- a/documentation/source/objects/anchor.rst
+++ b/documentation/source/objects/anchor.rst
@@ -5,13 +5,92 @@
 Anchor
 ######
 
+***********
+Description
+***********
+
 Anchors are single points in a glyph which are not part of a contour. They can be used as reference positions for doing things like assembling components. In most font editors, anchors have a special appearance and can be edited.
 
 ::
 
 	glyph = CurrentGlyph()
 	for anchor in glyph.anchors:
-	    print anchor
+		print anchor
+
+********
+Overview
+********
+
+Copy
+====
+
+.. autosummary::
+	:nosignatures:
+
+	BaseAnchor.copy
+
+Parents
+=======
+
+.. autosummary::
+	:nosignatures:
+
+	BaseAnchor.glyph
+	BaseAnchor.layer
+	BaseAnchor.font
+
+Identification
+==============
+
+.. autosummary::
+	:nosignatures:
+
+	BaseAnchor.name
+	BaseAnchor.color
+	BaseAnchor.identifier
+	BaseAnchor.index
+
+Coordinate
+==========
+
+.. autosummary::
+	:nosignatures:
+
+	BaseAnchor.x
+	BaseAnchor.y
+
+Transformations
+===============
+
+.. autosummary::
+	:nosignatures:
+
+	BaseAnchor.transformBy
+	BaseAnchor.moveBy
+	BaseAnchor.scaleBy
+	BaseAnchor.rotateBy
+	BaseAnchor.skewBy
+
+Normalization
+=============
+
+.. autosummary::
+	:nosignatures:
+
+	BaseAnchor.round
+
+Environment
+===========
+
+.. autosummary::
+	:nosignatures:
+
+	BaseAnchor.naked
+	BaseAnchor.changed
+
+*********
+Reference
+*********
 
 .. autoclass:: BaseAnchor
 
@@ -60,4 +139,3 @@ Environment
 
 .. automethod:: BaseAnchor.naked
 .. automethod:: BaseAnchor.changed
-

--- a/documentation/source/objects/bpoint.rst
+++ b/documentation/source/objects/bpoint.rst
@@ -5,6 +5,89 @@
 bPoint
 ######
 
+***********
+Description
+***********
+
+The :class:`bPoint <BaseBPoint>` is a point object which mimics the old “Bezier Point” from RoboFog. It has attributes for :attr:`bcpIn <BaseBPoint.bcpIn>`, anchor, bcpOut and type. The coordinates in bcpIn and bcpOut are relative to the position of the anchor. For instance, if the bcpIn is 20 units to the left of the anchor, its coordinates would be (-20,0), regardless of the coordinates of the anchor itself. Also: bcpIn will be (0,0) when it is “on top of the anchor”, i.e. when there is no bcp it will still have a value. The parent of a bPoint is usually a :class:`Contour <BaseContour>`.
+
+
+
+********
+Overview
+********
+
+Parents
+=======
+
+.. autosummary::
+    :nosignatures:
+
+    BaseBPoint.contour
+    BaseBPoint.glyph
+    BaseBPoint.layer
+    BaseBPoint.font
+
+Identification
+==============
+
+.. autosummary::
+    :nosignatures:
+
+    BaseBPoint.index
+
+Attributes
+==========
+
+.. autosummary::
+    :nosignatures:
+
+    BaseBPoint.type
+
+Points
+======
+
+.. autosummary::
+    :nosignatures:
+
+    BaseBPoint.anchor
+    BaseBPoint.bcpIn
+    BaseBPoint.bcpOut
+
+Transformations
+===============
+
+.. autosummary::
+    :nosignatures:
+
+    BaseBPoint.transformBy
+    BaseBPoint.moveBy
+    BaseBPoint.scaleBy
+    BaseBPoint.rotateBy
+    BaseBPoint.skewBy
+
+Normalization
+=============
+
+.. autosummary::
+    :nosignatures:
+
+    BaseBPoint.round
+
+Environment
+===========
+
+.. autosummary::
+    :nosignatures:
+
+    BaseBPoint.naked
+    BaseBPoint.changed
+
+
+*********
+Reference
+*********
+
 .. autoclass:: BaseBPoint
 
 Parents

--- a/documentation/source/objects/component.rst
+++ b/documentation/source/objects/component.rst
@@ -5,6 +5,108 @@
 Component
 #########
 
+***********
+Description
+***********
+
+A component can be a part of a glyph, and it is a reference to another glyph in the same font. With components you can make glyphs depend on other glyphs. Changes to the base glyph will reflect in the component as well.
+
+The parent of a component is usually a glyph. Components can be decomposed: they replace themselves with the actual outlines from the base glyph. When that happens, the link between the original and the component is broken: changes to the base glyph will no longer reflect in the glyph that had the component.
+
+********
+Overview
+********
+
+Parents
+=======
+
+.. autosummary::
+    :nosignatures:
+
+    BaseComponent.glyph
+    BaseComponent.layer
+    BaseComponent.font
+
+Copy
+====
+
+.. autosummary::
+    :nosignatures:
+
+    BaseComponent.copy
+
+Identification
+==============
+
+.. autosummary::
+    :nosignatures:
+
+    BaseComponent.identifier
+    BaseComponent.index
+
+Attributes
+==========
+
+.. autosummary::
+    :nosignatures:
+
+    BaseComponent.baseGlyph
+    BaseComponent.transformation
+    BaseComponent.offset
+    BaseComponent.scale
+
+Queries
+=======
+
+.. autosummary::
+    :nosignatures:
+
+    BaseComponent.bounds
+    BaseComponent.pointInside
+
+Pens and Drawing
+================
+
+.. autosummary::
+    :nosignatures:
+
+    BaseComponent.draw
+    BaseComponent.drawPoints
+
+Transformations
+===============
+
+.. autosummary::
+    :nosignatures:
+
+    BaseComponent.transformBy
+    BaseComponent.moveBy
+    BaseComponent.scaleBy
+    BaseComponent.rotateBy
+    BaseComponent.skewBy
+
+Normalization
+=============
+
+.. autosummary::
+    :nosignatures:
+
+    BaseComponent.decompose
+    BaseComponent.round
+
+Environment
+===========
+
+.. autosummary::
+    :nosignatures:
+
+    BaseComponent.naked
+    BaseComponent.changed
+
+*********
+Reference
+*********
+
 .. autoclass:: BaseComponent
 
 Parents

--- a/documentation/source/objects/contour.rst
+++ b/documentation/source/objects/contour.rst
@@ -5,6 +5,140 @@
 Contour
 #######
 
+***********
+Description
+***********
+
+A Contour is a single path of any number of points. A Glyph usually consists of a couple of contours, and this is the object that represents each one. The :class:`Contour <BaseContour>` object offers access to the outline matter in various ways. The parent of :class:`Contour <BaseContour>` is usually :class:`Glyph <BaseGlyph>`.
+
+********
+Overview
+********
+
+Copy
+====
+
+.. autosummary::
+    :nosignatures:
+
+    BaseContour.copy
+
+Parents
+=======
+
+.. autosummary::
+    :nosignatures:
+
+    BaseContour.glyph
+    BaseContour.layer
+    BaseContour.font
+
+Identification
+==============
+
+.. autosummary::
+    :nosignatures:
+
+    BaseContour.identifier
+    BaseContour.index
+
+Winding Direction
+=================
+
+.. autosummary::
+    :nosignatures:
+
+    BaseContour.clockwise
+    BaseContour.reverse
+
+Queries
+=======
+
+.. autosummary::
+    :nosignatures:
+
+    BaseContour.bounds
+    BaseContour.pointInside
+
+Pens and Drawing
+================
+
+.. autosummary::
+    :nosignatures:
+
+    BaseContour.draw
+    BaseContour.drawPoints
+
+Segments
+========
+
+.. autosummary::
+    :nosignatures:
+
+    BaseContour.segments
+    BaseContour.__len__
+    BaseContour.__iter__
+    BaseContour.__getitem__
+    BaseContour.appendSegment
+    BaseContour.insertSegment
+    BaseContour.removeSegment
+    BaseContour.setStartSegment
+    BaseContour.autoStartSegment
+
+bPoints
+=======
+
+.. autosummary::
+    :nosignatures:
+
+    BaseContour.bPoints
+    BaseContour.appendBPoint
+    BaseContour.insertBPoint
+
+Points
+======
+
+.. autosummary::
+    :nosignatures:
+
+    BaseContour.points
+    BaseContour.appendPoint
+    BaseContour.insertPoint
+    BaseContour.removePoint
+
+Transformations
+===============
+
+.. autosummary::
+    :nosignatures:
+
+    BaseContour.transformBy
+    BaseContour.moveBy
+    BaseContour.scaleBy
+    BaseContour.rotateBy
+    BaseContour.skewBy
+
+Normalization
+=============
+
+.. autosummary::
+    :nosignatures:
+
+    BaseContour.round
+
+Environment
+===========
+
+.. autosummary::
+    :nosignatures:
+
+    BaseContour.naked
+    BaseContour.changed
+
+*********
+Reference
+*********
+
 .. autoclass:: BaseContour
 
 Copy

--- a/documentation/source/objects/features.rst
+++ b/documentation/source/objects/features.rst
@@ -5,6 +5,10 @@
 Features
 ########
 
+***********
+Description
+***********
+
 Features is text in the `Adobe Font Development Kit <http://www.adobe.com/devnet/opentype/afdko.html>`_ for OpenType `.fea syntax <http://www.adobe.com/devnet/opentype/afdko/topic_feature_file_syntax.html>`_ that describes the OpenType features of your font. The `OpenType Cookbook <http://opentypecookbook.com>`_ is a great place to start learning how to write features. Your features must be self-contained; for example, any glyph or mark classes must be defined within the file. No assumption should be made about the validity of the syntax, and FontParts does not check the validity of the syntax.
 
 .. note:: It is important to note that the features file may contain data that is a duplicate of or data that is in conflict with the data in :class:`BaseKerning`, :class:`BaseGroups`, and :class:`BaseInfo`. Synchronization is up to the user and application developers.
@@ -13,6 +17,21 @@ Features is text in the `Adobe Font Development Kit <http://www.adobe.com/devnet
 
 	font = CurrentFont()
 	print font.features
+
+********
+Overview
+********
+
+.. autosummary::
+    :nosignatures:
+
+    BaseFeatures.copy
+    BaseFeatures.font
+    BaseFeatures.text
+
+*********
+Reference
+*********
 
 .. autoclass:: BaseFeatures
 

--- a/documentation/source/objects/font.rst
+++ b/documentation/source/objects/font.rst
@@ -9,10 +9,87 @@ Font
 
 	This section needs to contain the following:
 
-	* description of what this is
-	* sub-object with basic usage
-	* bridge to default layer for glyphs for backwards compatibility
-	* glyph interaction with basic usage
+	* description of what this is ✓
+	* sub-object with basic usage ✓
+	* bridge to default layer for glyphs for backwards compatibility ✗
+	* glyph interaction with basic usage ✗
+
+***********
+Description
+***********
+
+The :class:`Font <BaseFont>` object is the central part that connects all glyphs with font information like names, key dimensions etc.
+
+:class:`Font <BaseFont>` objects behave like dictionaries: the glyph name is the key and the returned value is a :class:`Glyph <BaseGlyph>` object for that glyph. If the glyph does not exist, :class:`Font <BaseFont>` will raise an ``IndexError``.
+
+:class:`Font <BaseFont>` has a couple of important sub-objects which are worth checking out. The font’s kerning is stored in a :class:`Kerning <BaseKerning>` object and can be reached as an attribute at ``Font.kerning``. Fontnames, key dimensions, flags etc are stored in a :class:`Info <BaseInfo>` object which is available through ``Font.info``. The ``Font.lib`` is a :class:`Lib <BaseLib>` object which behaves as a dictionary.
+
+********
+Overview
+********
+
+Copy
+====
+
+.. autosummary::
+    :nosignatures:
+
+    BaseFont.copy
+
+File Operations
+===============
+
+.. autosummary::
+    :nosignatures:
+
+    BaseFont.path
+    BaseFont.save
+    BaseFont.generate
+
+Sub-Objects
+===========
+
+.. autosummary::
+    :nosignatures:
+
+    BaseFont.info
+    BaseFont.groups
+    BaseFont.kerning
+    BaseFont.features
+    BaseFont.lib
+
+Layers
+======
+
+.. autosummary::
+    :nosignatures:
+
+    BaseFont.layers
+    BaseFont.layerOrder
+    BaseFont.defaultLayer
+    BaseFont.getLayer
+    BaseFont.newLayer
+    BaseFont.removeLayer
+
+Glyphs
+======
+
+.. autosummary::
+    :nosignatures:
+
+    BaseFont.__len__
+    BaseFont.keys
+    BaseFont.glyphOrder
+    BaseFont.__iter__
+    BaseFont.__contains__
+    BaseFont.__getitem__
+    BaseFont.newGlyph
+    BaseFont.insertGlyph
+    BaseFont.removeGlyph
+
+*********
+Reference
+*********
 
 .. autoclass:: BaseFont
 
@@ -94,4 +171,3 @@ Environment
 
 .. automethod:: BaseFont.naked
 .. automethod:: BaseFont.changed
-

--- a/documentation/source/objects/glyph.rst
+++ b/documentation/source/objects/glyph.rst
@@ -5,6 +5,219 @@
 Glyph
 #####
 
+***********
+Description
+***********
+
+The :class:`Glyph <BaseGlyph>` object represents a glyph, its parts and associated data.
+
+:class:`Glyph <BaseGlyph>` can be used as a list of :class:`Contour <BaseContour>` objects.
+
+When a :class:`Glyph <BaseGlyph>` is obtained from a :class:`Font <BaseFont>` object, the font is the parent object of the glyph.
+
+********
+Overview
+********
+
+Copy
+====
+
+.. autosummary::
+    :nosignatures:
+
+    BaseGlyph.copy
+
+Parents
+=======
+
+.. autosummary::
+    :nosignatures:
+
+    BaseGlyph.layer
+    BaseGlyph.font
+
+Identification
+==============
+
+.. autosummary::
+    :nosignatures:
+
+    BaseGlyph.name
+    BaseGlyph.unicodes
+    BaseGlyph.unicode
+
+Metrics
+=======
+
+.. autosummary::
+    :nosignatures:
+
+    BaseGlyph.width
+    BaseGlyph.leftMargin
+    BaseGlyph.rightMargin
+    BaseGlyph.height
+    BaseGlyph.bottomMargin
+    BaseGlyph.topMargin
+
+Queries
+=======
+
+.. autosummary::
+    :nosignatures:
+
+    BaseGlyph.bounds
+    BaseGlyph.pointInside
+
+Pens and Drawing
+================
+
+.. autosummary::
+    :nosignatures:
+
+    BaseGlyph.getPen
+    BaseGlyph.getPointPen
+    BaseGlyph.draw
+    BaseGlyph.drawPoints
+
+Layers
+======
+
+.. autosummary::
+    :nosignatures:
+
+    BaseGlyph.layers
+    BaseGlyph.getLayer
+    BaseGlyph.newLayer
+    BaseGlyph.removeLayer
+
+Global
+======
+
+.. autosummary::
+    :nosignatures:
+
+    BaseGlyph.clear
+    BaseGlyph.appendGlyph
+
+Contours
+========
+
+.. autosummary::
+    :nosignatures:
+
+    BaseGlyph.contours
+    BaseGlyph.__len__
+    BaseGlyph.__iter__
+    BaseGlyph.__getitem__
+    BaseGlyph.appendContour
+    BaseGlyph.removeContour
+    BaseGlyph.clearContours
+    BaseGlyph.removeOverlap
+
+Components
+==========
+
+.. autosummary::
+    :nosignatures:
+
+    BaseGlyph.components
+    BaseGlyph.appendComponent
+    BaseGlyph.removeComponent
+    BaseGlyph.clearComponents
+    BaseGlyph.decompose
+
+Anchors
+=======
+
+.. autosummary::
+    :nosignatures:
+
+    BaseGlyph.anchors
+    BaseGlyph.appendAnchor
+    BaseGlyph.removeAnchor
+    BaseGlyph.clearAnchors
+
+Guidelines
+==========
+
+.. autosummary::
+    :nosignatures:
+
+    BaseGlyph.guidelines
+    BaseGlyph.appendGuideline
+    BaseGlyph.removeGuideline
+    BaseGlyph.clearGuidelines
+
+Image
+=====
+
+.. autosummary::
+    :nosignatures:
+
+    BaseGlyph.image
+    BaseGlyph.addImage
+    BaseGlyph.clearImage
+
+Note
+====
+
+.. autosummary::
+    :nosignatures:
+
+    BaseGlyph.note
+    BaseGlyph.markColor
+
+Sub-Objects
+===========
+
+.. autosummary::
+    :nosignatures:
+
+    BaseGlyph.lib
+
+Transformations
+===============
+
+.. autosummary::
+    :nosignatures:
+
+    BaseGlyph.transformBy
+    BaseGlyph.moveBy
+    BaseGlyph.scaleBy
+    BaseGlyph.rotateBy
+    BaseGlyph.skewBy
+
+Interpolation
+=============
+
+.. autosummary::
+    :nosignatures:
+
+    BaseGlyph.isCompatible
+    BaseGlyph.interpolate
+
+Normalization
+=============
+
+.. autosummary::
+    :nosignatures:
+
+    BaseGlyph.round
+    BaseGlyph.autoUnicodes
+
+Environment
+===========
+
+.. autosummary::
+    :nosignatures:
+
+    BaseGlyph.naked
+    BaseGlyph.changed
+
+*********
+Reference
+*********
+
 .. autoclass:: BaseGlyph
 
 Copy
@@ -23,7 +236,6 @@ Identification
 
 .. autoattribute:: BaseGlyph.name
 .. autoattribute:: BaseGlyph.unicodes
-.. autoattribute:: BaseGlyph.unicode
 .. autoattribute:: BaseGlyph.unicode
 
 Metrics

--- a/documentation/source/objects/groups.rst
+++ b/documentation/source/objects/groups.rst
@@ -5,6 +5,10 @@
 Groups
 ######
 
+***********
+Description
+***********
+
 Groups are collections of glyphs. Groups are used for many things, from OpenType features, kerning, or just keeping track of a collection of related glyphs. The name of the group must be at least one character, with no limit to the maximum length for the name, nor any limit on the characters used in a name. With the exception of the kerning groups defined below, glyphs may be in more than one group and they may appear within the same group more than once. Glyphs in the groups are not required to be in the font.
 
 Groups behave like a Python dictionary. Anything you can do with a dictionary in Python, you can do with Groups.
@@ -16,8 +20,7 @@ Groups behave like a Python dictionary. Anything you can do with a dictionary in
         print name
         print members
 
-It is important to understand that any changes to the returned group contents
-will not be reflected in the groups object. This means that the following will not update the font's groups:
+It is important to understand that any changes to the returned group contents will not be reflected in the groups object. This means that the following will not update the font's groups:
 
 ::
 
@@ -33,11 +36,11 @@ If one wants to make a change to the group contents, one should do the following
     font.groups["myGroup"] = group
 
 Kerning Groups
---------------
+==============
 
 Groups may be used as members of kerning pairs in :class:`BaseKerning`. These groups are divided into two types: groups that appear on the first side of a kerning pair and groups that appear on the second side of a kerning pair.
 
-Kerning groups must begin with standard prefixes. The prefix for groups intended for use in the first side of a kerning pair is “public.kern1.”. The prefix for groups intended for use in the second side of a kerning pair is “public.kern2.”. One or more characters must follow the prefix.
+Kerning groups must begin with standard prefixes. The prefix for groups intended for use in the first side of a kerning pair is ``public.kern1.``. The prefix for groups intended for use in the second side of a kerning pair is ``public.kern2.``. One or more characters must follow the prefix.
 
 Kerning groups must strictly adhere to the following rules:
 
@@ -47,6 +50,36 @@ Kerning groups must strictly adhere to the following rules:
 #. Glyphs must not appear in more than one kerning group per side.
 
 These rules come from the `Unified Font Object <http://unifiedfontobject.org/versions/ufo3/groups.plist/>`_, more information on implementation details for application developers can be found there.
+
+********
+Overview
+********
+
+.. autosummary::
+    :nosignatures:
+
+    BaseGroups.copy
+    BaseGroups.font
+    BaseGroups.__contains__
+    BaseGroups.__delitem__
+    BaseGroups.__getitem__
+    BaseGroups.__iter__
+    BaseGroups.__len__
+    BaseGroups.__setitem__
+    BaseGroups.clear
+    BaseGroups.get
+    BaseGroups.items
+    BaseGroups.keys
+    BaseGroups.pop
+    BaseGroups.update
+    BaseGroups.values
+    BaseGroups.findGlyph
+    BaseGroups.naked
+    BaseGroups.changed
+
+*********
+Reference
+*********
 
 .. autoclass:: BaseGroups
 

--- a/documentation/source/objects/guideline.rst
+++ b/documentation/source/objects/guideline.rst
@@ -5,13 +5,93 @@
 Guideline
 #########
 
+***********
+Description
+***********
+
 Guidelines are reference lines in a glyph that are not part of a contour or the generated font data. They are defined by a point and an angle; the guideline extends from the point in both directions on the specified angle. They are most often used to keep track of design information for a font ('my overshoots should be here') or to measure positions in a glyph ('line the ends of my serifs on this line'). They can also be used as reference positions for doing things like assembling components. In most font editors, guidelines have a special appearance and can be edited.
 
 ::
 
 	glyph = CurrentGlyph()
 	for guideline in glyph.guidelines:
-	    print guideline
+		print guideline
+
+********
+Overview
+********
+
+Copy
+====
+
+.. autosummary::
+    :nosignatures:
+
+	BaseGuideline.copy
+
+Parents
+=======
+
+.. autosummary::
+    :nosignatures:
+
+	BaseGuideline.glyph
+	BaseGuideline.layer
+	BaseGuideline.font
+
+Identification
+==============
+
+.. autosummary::
+    :nosignatures:
+
+	BaseGuideline.name
+	BaseGuideline.color
+	BaseGuideline.identifier
+	BaseGuideline.index
+
+Attributes
+==========
+
+.. autosummary::
+    :nosignatures:
+
+	BaseGuideline.x
+	BaseGuideline.y
+	BaseGuideline.angle
+
+Transformations
+===============
+
+.. autosummary::
+    :nosignatures:
+
+	BaseGuideline.transformBy
+	BaseGuideline.moveBy
+	BaseGuideline.scaleBy
+	BaseGuideline.rotateBy
+	BaseGuideline.skewBy
+
+Normalization
+=============
+
+.. autosummary::
+    :nosignatures:
+
+	BaseGuideline.round
+
+Environment
+===========
+
+.. autosummary::
+    :nosignatures:
+
+	BaseGuideline.naked
+	BaseGuideline.changed
+
+*********
+Reference
+*********
 
 .. autoclass:: BaseGuideline
 

--- a/documentation/source/objects/image.rst
+++ b/documentation/source/objects/image.rst
@@ -5,6 +5,36 @@
 Image
 #####
 
+********
+Overview
+********
+
+.. autosummary::
+    :nosignatures:
+
+    BaseImage.copy
+    BaseImage.glyph
+    BaseImage.layer
+    BaseImage.font
+    BaseImage.data
+    BaseImage.color
+    BaseImage.transformation
+    BaseImage.offset
+    BaseImage.scale
+    BaseImage.transformBy
+    BaseImage.moveBy
+    BaseImage.scaleBy
+    BaseImage.rotateBy
+    BaseImage.skewBy
+    BaseImage.round
+    BaseImage.naked
+    BaseImage.changed
+
+
+*********
+Reference
+*********
+
 .. autoclass:: BaseImage
 
 Copy

--- a/documentation/source/objects/info.rst
+++ b/documentation/source/objects/info.rst
@@ -5,6 +5,32 @@
 Info
 ####
 
+***********
+Description
+***********
+
+The :class:`Info <BaseInfo>` object contains all names, numbers, URLs, dimensions, values, etc. that would otherwise clutter up the font object. You don't have to create a :class:`Info <BaseInfo>` object yourself, :class:`Font <BaseFont>` makes one when it is created.
+
+:class:`Info <BaseInfo>` doesn’t check the validity of the entries, it just provides storage or access to them.
+
+********
+Overview
+********
+
+.. autosummary::
+    :nosignatures:
+
+    BaseInfo.copy
+    BaseInfo.font
+    BaseInfo.interpolate
+    BaseInfo.round
+    BaseInfo.naked
+    BaseInfo.changed
+
+*********
+Reference
+*********
+
 .. autoclass:: BaseInfo
 
 Copy

--- a/documentation/source/objects/kerning.rst
+++ b/documentation/source/objects/kerning.rst
@@ -5,40 +5,97 @@
 Kerning
 #######
 
-Kerning represents the kerning data of a font. It behaves like a Python dictionary with the key being the kerning pair and the value being the kerning value. Kerning pairs can contain :class:`BaseGroups` or glyph names. If the Kerning uses :class:`BaseGroups`, the group names must follow the rules for kerning groups.
+***********
+Description
+***********
 
-::
+Kerning groups must begin with standard prefixes. The prefix for groups intended for use in the first side of a kerning pair is ``public.kern1.``. The prefix for groups intended for use in the second side of a kerning pair is ``public.kern2.``. One or more characters must follow the prefix.
 
-    font = CurrentFont()
-    for pair, value in font.kerning.keys():
-        print pair
-        print value
+Kerning groups must strictly adhere to the following rules:
 
-It is important to understand that any changes to the returned kerning
-will not be reflected in the kerning object. This means that the following will not update the font's kerning:
+#. Kerning group names must begin with the appropriate prefix.
+#. Only kerning groups are allowed to use the kerning group prefixes in their names.
+#. Kerning groups are not required to appear in the kerning pairs.
+#. Glyphs must not appear in more than one kerning group per side.
 
-::
+These rules come from the `Unified Font Object <http://unifiedfontobject.org/versions/ufo3/groups.plist/>`_, more information on implementation details for application developers can be found there.
 
-    kerning = font.kerning
-    for pair in kerning:
-        kerning[pair] += 10
+********
+Overview
+********
 
-If one wants to make a change to the kerning, one should do the following instead:
+Copy
+====
 
-::
+.. autosummary::
+    :nosignatures:
 
-    kerning = font.kerning
-    for pair in kerning:
-        kerning[pair] = kerning[pair] + 10
-    font.kerning.update(kerning)
+    BaseKerning.copy
 
-If one wants to update the kerning for a pair, this will directly update the font's kerning, without needing to use the :meth:`BaseKerning.update` method.
+Parents
+=======
 
-::
+.. autosummary::
+    :nosignatures:
 
-    font.kerning[pair] = 10
+    BaseKerning.font
 
-.. note:: It is important to note that :class:`BaseFeatures` may contain data that is a duplicate of or data that is in conflict with the data in Kerning. Synchronization is up to the user and application developers.
+Dictionary
+==========
+
+.. autosummary::
+    :nosignatures:
+
+    BaseKerning.__len__
+    BaseKerning.keys
+    BaseKerning.items
+    BaseKerning.values
+    BaseKerning.__contains__
+    BaseKerning.__setitem__
+    BaseKerning.__getitem__
+    BaseKerning.get
+    BaseKerning.__delitem__
+    BaseKerning.pop
+    BaseKerning.__iter__
+    BaseKerning.update
+    BaseKerning.clear
+
+Transformations
+===============
+
+.. autosummary::
+    :nosignatures:
+
+    BaseKerning.scaleBy
+
+Interpolation
+=============
+
+.. autosummary::
+    :nosignatures:
+
+    BaseKerning.interpolate
+
+Normalization
+=============
+
+.. autosummary::
+    :nosignatures:
+
+    BaseKerning.round
+
+Environment
+===========
+
+.. autosummary::
+    :nosignatures:
+
+    BaseKerning.naked
+    BaseKerning.changed
+
+*********
+Reference
+*********
 
 .. autoclass:: BaseKerning
 

--- a/documentation/source/objects/layer.rst
+++ b/documentation/source/objects/layer.rst
@@ -13,6 +13,90 @@ Layer
 	* sub-object with basic usage
 	* glyph interaction with basic usage
 
+********
+Overview
+********
+
+Copy
+====
+
+.. autosummary::
+    :nosignatures:
+
+    BaseLayer.copy
+
+Parents
+=======
+
+.. autosummary::
+    :nosignatures:
+
+    BaseLayer.font
+
+Attributes
+==========
+
+.. autosummary::
+    :nosignatures:
+
+    BaseLayer.name
+    BaseLayer.color
+
+Sub-Objects
+===========
+
+.. autosummary::
+    :nosignatures:
+
+    BaseLayer.lib
+
+Glyphs
+======
+
+.. autosummary::
+    :nosignatures:
+
+    BaseLayer.__len__
+    BaseLayer.keys
+    BaseLayer.__iter__
+    BaseLayer.__contains__
+    BaseLayer.__getitem__
+    BaseLayer.newGlyph
+    BaseLayer.insertGlyph
+    BaseLayer.removeGlyph
+
+Interpolation
+=============
+
+.. autosummary::
+    :nosignatures:
+
+    BaseLayer.isCompatible
+    BaseLayer.interpolate
+
+Normalization
+=============
+
+.. autosummary::
+    :nosignatures:
+
+    BaseLayer.round
+    BaseLayer.autoUnicodes
+
+Environment
+===========
+
+.. autosummary::
+    :nosignatures:
+
+    BaseLayer.naked
+    BaseLayer.changed
+
+
+*********
+Reference
+*********
+
 .. autoclass:: BaseLayer
 
 Copy

--- a/documentation/source/objects/lib.rst
+++ b/documentation/source/objects/lib.rst
@@ -5,6 +5,37 @@
 Lib
 ###
 
+********
+Overview
+********
+
+.. autosummary::
+    :nosignatures:
+
+    BaseLib.copy
+    BaseLib.glyph
+    BaseLib.font
+    BaseLib.__len__
+    BaseLib.keys
+    BaseLib.items
+    BaseLib.values
+    BaseLib.__contains__
+    BaseLib.__setitem__
+    BaseLib.__getitem__
+    BaseLib.get
+    BaseLib.__delitem__
+    BaseLib.pop
+    BaseLib.__iter__
+    BaseLib.update
+    BaseLib.clear
+    BaseLib.naked
+    BaseLib.changed
+
+
+*********
+Reference
+*********
+
 .. autoclass:: BaseLib
 
 Copy

--- a/documentation/source/objects/point.rst
+++ b/documentation/source/objects/point.rst
@@ -5,7 +5,11 @@
 Point
 #####
 
-Points are single points in a contour. These can be on-curve or off-curve and they have various possible attributes.
+***********
+Description
+***********
+
+:class:`Point <BasePoint>` represents one single point with a particular coordinate in a contour. It is used to access off-curve and on-curve points alike. Its cousin :class:`BPoint <BaseBPoint>` also provides access to incoming and outgoing bcps. :class:`Point <BasePoint>` is exclusively only one single point.
 
 ::
 
@@ -13,6 +17,90 @@ Points are single points in a contour. These can be on-curve or off-curve and th
 	for contour in glyph:
 		for point in contour.points:
 			print point
+
+********
+Overview
+********
+
+Copy
+====
+
+.. autosummary::
+    :nosignatures:
+
+    BasePoint.copy
+
+Parents
+=======
+
+.. autosummary::
+    :nosignatures:
+
+    BasePoint.contour
+    BasePoint.glyph
+    BasePoint.layer
+    BasePoint.font
+
+Identification
+==============
+
+.. autosummary::
+    :nosignatures:
+
+    BasePoint.name
+    BasePoint.identifier
+    BasePoint.index
+
+Coordinate
+==========
+
+.. autosummary::
+    :nosignatures:
+
+    BasePoint.x
+    BasePoint.y
+
+Type
+====
+
+.. autosummary::
+    :nosignatures:
+
+    BasePoint.type
+    BasePoint.smooth
+
+Transformations
+===============
+
+.. autosummary::
+    :nosignatures:
+
+    BasePoint.transformBy
+    BasePoint.moveBy
+    BasePoint.scaleBy
+    BasePoint.rotateBy
+    BasePoint.skewBy
+
+Normalization
+=============
+
+.. autosummary::
+    :nosignatures:
+
+    BasePoint.round
+
+Environment
+===========
+
+.. autosummary::
+    :nosignatures:
+
+    BasePoint.naked
+    BasePoint.changed
+
+*********
+Reference
+*********
 
 Copy
 ====

--- a/documentation/source/objects/segment.rst
+++ b/documentation/source/objects/segment.rst
@@ -5,6 +5,87 @@
 Segment
 #######
 
+***********
+Description
+***********
+
+A :class:`Contour <BaseContour>` object is a list of segments. A :class:`Segment <BaseSegment>` is a list of points with some special attributes and methods.
+
+********
+Overview
+********
+
+Parents
+=======
+
+.. autosummary::
+    :nosignatures:
+
+    BaseSegment.contour
+    BaseSegment.glyph
+    BaseSegment.layer
+    BaseSegment.font
+
+Identification
+==============
+
+.. autosummary::
+    :nosignatures:
+
+    BaseSegment.index
+
+Attributes
+==========
+
+.. autosummary::
+    :nosignatures:
+
+    BaseSegment.type
+    BaseSegment.smooth
+
+Points
+======
+
+.. autosummary::
+    :nosignatures:
+
+    BaseSegment.points
+    BaseSegment.onCurve
+    BaseSegment.offCurve
+
+Transformations
+===============
+
+.. autosummary::
+    :nosignatures:
+
+    BaseSegment.transformBy
+    BaseSegment.moveBy
+    BaseSegment.scaleBy
+    BaseSegment.rotateBy
+    BaseSegment.skewBy
+
+Normalization
+=============
+
+.. autosummary::
+    :nosignatures:
+
+    BaseSegment.round
+
+Environment
+===========
+
+.. autosummary::
+    :nosignatures:
+
+    BaseSegment.naked
+    BaseSegment.changed
+
+*********
+Reference
+*********
+
 .. autoclass:: BaseSegment
 
 Parents


### PR DESCRIPTION
Adding a quick reference to the top of doc pages, using the [autosummary](http://www.sphinx-doc.org/en/1.5.2/ext/autosummary.html) extension. Also adding missing object descriptions (copied from the robofab docs).