### PR TITLE
Renames generateIdentifier() methods to the name getIdentifier()...

### DIFF
--- a/Lib/fontParts/base/anchor.py
+++ b/Lib/fontParts/base/anchor.py
@@ -223,7 +223,7 @@ class BaseAnchor(BaseObject, TransformationMixin, DeprecatedAnchor):
             'ILHGJlygfds'
 
         To request an identifier if it does not exist use
-        `anchor.generateIdentifier()`
+        `anchor.getIdentifier()`
         """
     )
 
@@ -242,14 +242,14 @@ class BaseAnchor(BaseObject, TransformationMixin, DeprecatedAnchor):
         """
         self.raiseNotImplementedError()
 
-    def generateIdentifier(self):
+    def getIdentifier(self):
         """
         Create a new, unique identifier for and assign it to the anchor.
         If the anchor already has an identifier, the existing one should be returned.
         """
-        return self._generateIdentifier()
+        return self._getIdentifier()
 
-    def _generateIdentifier(self):
+    def _getIdentifier(self):
         """
         Subclasses must override this method.
         """

--- a/Lib/fontParts/base/bPoint.py
+++ b/Lib/fontParts/base/bPoint.py
@@ -4,9 +4,10 @@ from fontParts.base.errors import FontPartsError
 from fontParts.base.base import (
     BaseObject, TransformationMixin, dynamicProperty)
 from fontParts.base import normalizers
+from fontParts.base.deprecated import DeprecatedBPoint
 
 
-class BaseBPoint(BaseObject, TransformationMixin):
+class BaseBPoint(BaseObject, TransformationMixin, DeprecatedBPoint):
 
     def _reprContents(self):
         contents = [
@@ -49,18 +50,18 @@ class BaseBPoint(BaseObject, TransformationMixin):
         """
         return self._point.identifier
 
-    def generateIdentifier(self):
+    def getIdentifier(self):
         """
         Create a new, unique identifier for and assign it to the bPoint.
         If the point already has an identifier, the existing one should be returned.
         """
-        return self._generateIdentifier()
+        return self._getIdentifier()
 
-    def _generateIdentifier(self):
+    def _getIdentifier(self):
         """
         Subclasses may override this method.
         """
-        return self._point.generateIdentifier()
+        return self._point.getIdentifier()
 
     # Segment
 

--- a/Lib/fontParts/base/component.py
+++ b/Lib/fontParts/base/component.py
@@ -236,14 +236,14 @@ class BaseComponent(BaseObject, TransformationMixin, DeprecatedComponent):
         """
         self.raiseNotImplementedError()
 
-    def generateIdentifier(self):
+    def getIdentifier(self):
         """
         Create a new, unique identifier for and assign it to the component.
         If the component already has an identifier, the existing one should be returned.
         """
-        return self._generateIdentifier()
+        return self._getIdentifier()
 
-    def _generateIdentifier(self):
+    def _getIdentifier(self):
         """
         Subclasses must override this method.
         """

--- a/Lib/fontParts/base/contour.py
+++ b/Lib/fontParts/base/contour.py
@@ -457,8 +457,8 @@ class BaseContour(BaseObject, TransformationMixin, DeprecatedContour):
         onCurve = points[-1]
         offCurve = points[:-1]
         self.insertPoint(index, onCurve, type=type, smooth=smooth)
-        for point in reversed(offCurve):
-            self.insertPoint(index, offCurve, type="offcurve")
+        for offCurvePoint in reversed(offCurve):
+            self.insertPoint(index, offCurvePoint, type="offcurve")
 
     def removeSegment(self, segment, **kwargs):
         """

--- a/Lib/fontParts/base/contour.py
+++ b/Lib/fontParts/base/contour.py
@@ -130,28 +130,28 @@ class BaseContour(BaseObject, TransformationMixin, DeprecatedContour):
         """
         self.raiseNotImplementedError()
 
-    def generateIdentifier(self):
+    def getIdentifier(self):
         """
         Create a new, unique identifier for and assign it to the contour.
         If the contour already has an identifier, the existing one should be returned.
         """
-        return self._generateIdentifier()
+        return self._getIdentifier()
 
-    def _generateIdentifier(self):
+    def _getIdentifier(self):
         """
         Subclasses must override this method.
         """
         self.raiseNotImplementedError()
 
-    def generateIdentifierForPoint(self, point):
+    def getIdentifierForPoint(self, point):
         """
         Create a new, unique identifier for and assign it to the point.
         If the point already has an identifier, the existing one should be returned.
         """
         point = normalizers.normalizePoint(point)
-        return self._generateIdentifierforPoint(point)
+        return self._getIdentifierforPoint(point)
 
-    def _generateIdentifierforPoint(self, point):
+    def _getIdentifierforPoint(self, point):
         """
         Subclasses must override this method.
         """

--- a/Lib/fontParts/base/deprecated.py
+++ b/Lib/fontParts/base/deprecated.py
@@ -65,14 +65,33 @@ class DeprecatedTransformation(object):
         self.skewBy(*args, **kwargs)
 
 
-# ==========
+# =========
 # = Point =
-# ==========
+# =========
 
 class DeprecatedPoint(DeprecatedBase, DeprecatedTransformation):
 
     def select(self, state=True):
         warnings.warn("'Point.select'", DeprecationWarning)
+
+    def _generateIdentifier(self):
+        warnings.warn("'Point._generateIdentifier()': use 'Point._getIdentifier()'", DeprecationWarning)
+
+    def generateIdentifier(self):
+        warnings.warn("'Point.generateIdentifier()': use 'Point.getIdentifier()'", DeprecationWarning)
+
+
+# ==========
+# = BPoint =
+# ==========
+
+class DeprecatedBPoint(DeprecatedBase, DeprecatedTransformation):
+
+    def _generateIdentifier(self):
+        warnings.warn("'BPoint._generateIdentifier()': use 'BPoint._getIdentifier()'", DeprecationWarning)
+
+    def generateIdentifier(self):
+        warnings.warn("'BPoint.generateIdentifier()': use 'BPoint.getIdentifier()'", DeprecationWarning)
 
 
 # ==========
@@ -99,6 +118,12 @@ class DeprecatedAnchor(DeprecatedBase, DeprecatedTransformation):
     def drawPoints(self, pen):
         warnings.warn("'Anchor.drawPoints': UFO3 is not drawing anchors into point pens", DeprecationWarning)
 
+    def _generateIdentifier(self):
+        warnings.warn("'Anchor._generateIdentifier()': use 'Anchor._getIdentifier()'", DeprecationWarning)
+
+    def generateIdentifier(self):
+        warnings.warn("'Anchor.generateIdentifier()': use 'Anchor.getIdentifier()'", DeprecationWarning)
+
 
 # =============
 # = Component =
@@ -111,6 +136,12 @@ class DeprecatedComponent(DeprecatedBase, DeprecatedTransformation):
         return self.bounds
 
     box = property(_get_box, doc="Deprecated Component.box")
+
+    def _generateIdentifier(self):
+        warnings.warn("'Component._generateIdentifier()': use 'Component._getIdentifier()'", DeprecationWarning)
+
+    def generateIdentifier(self):
+        warnings.warn("'Component.generateIdentifier()': use 'Component.getIdentifier()'", DeprecationWarning)
 
 
 # ===========
@@ -141,6 +172,18 @@ class DeprecatedContour(DeprecatedBase, DeprecatedTransformation):
     def reverseContour(self):
         warnings.warn("'Contour.reverseContour()': use 'Contour.reverse()'", DeprecationWarning)
         self.reverse()
+
+    def _generateIdentifier(self):
+        warnings.warn("'Contour._generateIdentifier()': use 'Contour._getIdentifier()'", DeprecationWarning)
+
+    def generateIdentifier(self):
+        warnings.warn("'Contour.generateIdentifier()': use 'Contour.getIdentifier()'", DeprecationWarning)
+
+    def _generateIdentifierforPoint(self):
+        warnings.warn("'Contour._generateIdentifierforPoint()': use 'Contour._getIdentifierforPoint()'", DeprecationWarning)
+
+    def generateIdentifierforPoint(self):
+        warnings.warn("'Contour.generateIdentifierforPoint()': use 'Contour.getIdentifierforPoint()'", DeprecationWarning)
 
 
 # =========
@@ -181,6 +224,19 @@ class DeprecatedGlyph(DeprecatedBase, DeprecatedTransformation):
 
     def clearHGuides(self):
         warnings.warn("'Glyph.clearHGuides()': use Glyph.clearGuidelines()", DeprecationWarning)
+
+
+# =============
+# = Guideline =
+# =============
+
+class DeprecatedGuideline(DeprecatedBase, DeprecatedTransformation):
+
+    def _generateIdentifier(self):
+        warnings.warn("'Guideline._generateIdentifier()': use 'Guideline._getIdentifier()'", DeprecationWarning)
+
+    def generateIdentifier(self):
+        warnings.warn("'Guideline.generateIdentifier()': use 'Guideline.getIdentifier()'", DeprecationWarning)
 
 
 # =======

--- a/Lib/fontParts/base/deprecated.py
+++ b/Lib/fontParts/base/deprecated.py
@@ -76,9 +76,11 @@ class DeprecatedPoint(DeprecatedBase, DeprecatedTransformation):
 
     def _generateIdentifier(self):
         warnings.warn("'Point._generateIdentifier()': use 'Point._getIdentifier()'", DeprecationWarning)
+        return self._getIdentifier()
 
     def generateIdentifier(self):
         warnings.warn("'Point.generateIdentifier()': use 'Point.getIdentifier()'", DeprecationWarning)
+        return self.getIdentifier()
 
 
 # ==========
@@ -89,9 +91,11 @@ class DeprecatedBPoint(DeprecatedBase, DeprecatedTransformation):
 
     def _generateIdentifier(self):
         warnings.warn("'BPoint._generateIdentifier()': use 'BPoint._getIdentifier()'", DeprecationWarning)
+        return self._getIdentifier()
 
     def generateIdentifier(self):
         warnings.warn("'BPoint.generateIdentifier()': use 'BPoint.getIdentifier()'", DeprecationWarning)
+        return self.getIdentifier()
 
 
 # ==========
@@ -120,9 +124,11 @@ class DeprecatedAnchor(DeprecatedBase, DeprecatedTransformation):
 
     def _generateIdentifier(self):
         warnings.warn("'Anchor._generateIdentifier()': use 'Anchor._getIdentifier()'", DeprecationWarning)
+        return self._getIdentifier()
 
     def generateIdentifier(self):
         warnings.warn("'Anchor.generateIdentifier()': use 'Anchor.getIdentifier()'", DeprecationWarning)
+        return self.getIdentifier()
 
 
 # =============
@@ -139,9 +145,11 @@ class DeprecatedComponent(DeprecatedBase, DeprecatedTransformation):
 
     def _generateIdentifier(self):
         warnings.warn("'Component._generateIdentifier()': use 'Component._getIdentifier()'", DeprecationWarning)
+        return self._getIdentifier()
 
     def generateIdentifier(self):
         warnings.warn("'Component.generateIdentifier()': use 'Component.getIdentifier()'", DeprecationWarning)
+        return self.getIdentifier()
 
 
 # ===========
@@ -175,15 +183,19 @@ class DeprecatedContour(DeprecatedBase, DeprecatedTransformation):
 
     def _generateIdentifier(self):
         warnings.warn("'Contour._generateIdentifier()': use 'Contour._getIdentifier()'", DeprecationWarning)
+        return self._getIdentifier()
 
     def generateIdentifier(self):
         warnings.warn("'Contour.generateIdentifier()': use 'Contour.getIdentifier()'", DeprecationWarning)
+        return self.getIdentifier()
 
     def _generateIdentifierforPoint(self):
         warnings.warn("'Contour._generateIdentifierforPoint()': use 'Contour._getIdentifierforPoint()'", DeprecationWarning)
+        return self._getIdentifierforPoint()
 
     def generateIdentifierforPoint(self):
         warnings.warn("'Contour.generateIdentifierforPoint()': use 'Contour.getIdentifierforPoint()'", DeprecationWarning)
+        return self.getIdentifierforPoint()
 
 
 # =========
@@ -234,9 +246,11 @@ class DeprecatedGuideline(DeprecatedBase, DeprecatedTransformation):
 
     def _generateIdentifier(self):
         warnings.warn("'Guideline._generateIdentifier()': use 'Guideline._getIdentifier()'", DeprecationWarning)
+        return self._getIdentifier()
 
     def generateIdentifier(self):
         warnings.warn("'Guideline.generateIdentifier()': use 'Guideline.getIdentifier()'", DeprecationWarning)
+        return self.getIdentifier()
 
 
 # =======

--- a/Lib/fontParts/base/guideline.py
+++ b/Lib/fontParts/base/guideline.py
@@ -6,6 +6,7 @@ from fontParts.base.base import (
     BaseObject, TransformationMixin, dynamicProperty)
 from fontParts.base import normalizers
 from fontParts.base.color import Color
+from fontParts.base.deprecated import DeprecatedGuideline
 
 
 class BaseGuideline(BaseObject, TransformationMixin):
@@ -363,7 +364,7 @@ class BaseGuideline(BaseObject, TransformationMixin):
             'ILHGJlygfds'
 
         To request an identifier if it does not exist use
-        `guideline.generateIdentifier()`
+        `guideline.getIdentifier()`
         """
     )
 
@@ -384,14 +385,14 @@ class BaseGuideline(BaseObject, TransformationMixin):
         """
         self.raiseNotImplementedError()
 
-    def generateIdentifier(self):
+    def getIdentifier(self):
         """
         Create a new, unique identifier for and assign it to the guideline.
         If the guideline already has an identifier, the existing one should be returned.
         """
-        return self._generateIdentifier()
+        return self._getIdentifier()
 
-    def _generateIdentifier(self):
+    def _getIdentifier(self):
         """
         Subclasses must override this method.
         """

--- a/Lib/fontParts/base/point.py
+++ b/Lib/fontParts/base/point.py
@@ -378,7 +378,7 @@ class BasePoint(BaseObject, TransformationMixin, DeprecatedPoint):
             'ILHGJlygfds'
 
         To request an identifier if it does not exist use
-        `anchor.generateIdentifier()`
+        `anchor.getIdentifier()`
         """
     )
 
@@ -399,14 +399,14 @@ class BasePoint(BaseObject, TransformationMixin, DeprecatedPoint):
         """
         self.raiseNotImplementedError()
 
-    def generateIdentifier(self):
+    def getIdentifier(self):
         """
         Create a new, unique identifier for and assign it to the point.
         If the point already has an identifier, the existing one should be returned.
         """
-        return self._generateIdentifier()
+        return self._getIdentifier()
 
-    def _generateIdentifier(self):
+    def _getIdentifier(self):
         """
         Subclasses must override this method.
         """

--- a/Lib/fontParts/nonelab/anchor.py
+++ b/Lib/fontParts/nonelab/anchor.py
@@ -44,9 +44,9 @@ class RAnchor(RBaseObject, BaseAnchor):
         anchor = self.naked()
         return anchor.identifier
 
-    def _generateIdentifier(self):
+    def _getIdentifier(self):
         anchor = self.naked()
-        return anchor.generateIdentifier()
+        return anchor.getIdentifier()
 
     # name
 

--- a/Lib/fontParts/nonelab/component.py
+++ b/Lib/fontParts/nonelab/component.py
@@ -47,9 +47,9 @@ class RComponent(RBaseObject, BaseComponent):
         component = self.naked()
         return component.identifier
 
-    def _generateIdentifier(self):
+    def _getIdentifier(self):
         component = self.naked()
-        return component.generateIdentifier()
+        return component.getIdentifier()
 
     # -------------
     # Normalization

--- a/Lib/fontParts/nonelab/contour.py
+++ b/Lib/fontParts/nonelab/contour.py
@@ -33,14 +33,14 @@ class RContour(RBaseObject, BaseContour):
         contour = self.naked()
         return contour.identifier
 
-    def _generateIdentifier(self):
+    def _getIdentifier(self):
         contour = self.naked()
-        return contour.generateIdentifier()
+        return contour.getIdentifier()
 
-    def _generateIdentifierforPoint(self, point):
+    def _getIdentifierforPoint(self, point):
         contour = self.naked()
         point = point.naked()
-        return contour.generateIdentifierforPoint(point)
+        return contour.getIdentifierforPoint(point)
 
     # ----
     # Open

--- a/Lib/fontParts/nonelab/guideline.py
+++ b/Lib/fontParts/nonelab/guideline.py
@@ -53,9 +53,9 @@ class RGuideline(RBaseObject, BaseGuideline):
         guideline = self.naked()
         return guideline.identifier
 
-    def _generateIdentifier(self):
+    def _getIdentifier(self):
         guideline = self.naked()
-        return guideline.generateIdentifier()
+        return guideline.getIdentifier()
 
     # name
 

--- a/Lib/fontParts/nonelab/point.py
+++ b/Lib/fontParts/nonelab/point.py
@@ -71,14 +71,14 @@ class RPoint(RBaseObject, BasePoint):
         point = self.naked()
         return point.identifier
 
-    def _generateIdentifier(self):
+    def _getIdentifier(self):
         point = self.naked()
         value = point.identifier
         if value is not None:
             return value
         contour = self.contour.naked()
         if contour is not None:
-            contour.generateIdentifierForPoint(point)
+            contour.getIdentifierForPoint(point)
             value = point.identifier
         else:
             raise FontPartsError("An identifier can not be generated for this point because it does not belong to a contour.")


### PR DESCRIPTION
...and adds deprecation warnings for the old names. In reference to issue #85 
