### PR TITLE
Fixes segment order when a closed contour ends in a line segment

### DIFF
--- a/Lib/fontParts/base/contour.py
+++ b/Lib/fontParts/base/contour.py
@@ -368,6 +368,7 @@ class BaseContour(BaseObject, TransformationMixin, DeprecatedContour):
         segments = [[]]
         lastWasOffCurve = False
         firstIsMove = points[0].type == "move"
+        firstIsLine = points[0].type == "line"
         for point in points:
             segments[-1].append(point)
             if point.type != "offcurve":
@@ -383,6 +384,9 @@ class BaseContour(BaseObject, TransformationMixin, DeprecatedContour):
             assert len(segments[0]) == 1
             segment.append(segments[0][0])
             del segments[0]
+            segments.append(segment)
+        if not lastWasOffCurve and firstIsLine:
+            segment = segments.pop(0)
             segments.append(segment)
         # wrap into segments
         wrapped = []

--- a/Lib/fontParts/base/contour.py
+++ b/Lib/fontParts/base/contour.py
@@ -368,7 +368,6 @@ class BaseContour(BaseObject, TransformationMixin, DeprecatedContour):
         segments = [[]]
         lastWasOffCurve = False
         firstIsMove = points[0].type == "move"
-        firstIsLine = points[0].type == "line"
         for point in points:
             segments[-1].append(point)
             if point.type != "offcurve":
@@ -385,7 +384,7 @@ class BaseContour(BaseObject, TransformationMixin, DeprecatedContour):
             segment.append(segments[0][0])
             del segments[0]
             segments.append(segment)
-        if not lastWasOffCurve and firstIsLine:
+        if not lastWasOffCurve and not firstIsMove:
             segment = segments.pop(0)
             segments.append(segment)
         # wrap into segments


### PR DESCRIPTION
The expected behavior is that a contour's first segment's onCurve is the same point as the contour's second bPoint (that's a mouthful)

`_get_segments()` currently moves the first point of a closed contour to be the onCurve for the last segment when that last segment has offCurves (this is the correct behavior) but the points also need to be reordered if the last segment has no offCurves — the first point still needs to move to the end of the contour.

Sample glif file with two contours, one ends in a curve segment and one ends in a line segment:
```
<?xml version="1.0" encoding="UTF-8"?>
<glyph name="a" format="2">
  <outline>
    <contour>
      <point x="140" y="50" type="curve"/>
      <point x="140" y="124" type="line"/>
      <point x="66" y="124" type="line"/>
      <point x="66" y="83"/>
      <point x="100" y="50"/>
    </contour>
    <contour>
      <point x="240" y="50" type="line"/>
      <point x="240" y="124" type="line"/>
      <point x="166" y="124" type="line"/>
    </contour>
  </outline>
</glyph>
```

Sample code, the points match up when the contour ends in a curve segment but not when the contour ends in a line segment:
``` python
g = CurrentGlyph()
for c in g.contours:
    # Second bPoint
    bPtLoc = c.bPoints[1].anchor
    print bPtLoc
    # First segment onCurve
    segPt = c.segments[0].onCurve
    print (segPt.x, segPt.y)
    # Compare:
    print (segPt.x, segPt.y) == bPtLoc
```