### PR TITLE
Fixes the copying of font info attributes

### DIFF
--- a/Lib/fontParts/base/info.py
+++ b/Lib/fontParts/base/info.py
@@ -10,7 +10,7 @@ from fontParts.base.deprecated import DeprecatedInfo
 
 class BaseInfo(BaseObject, DeprecatedInfo):
 
-    copyAttributes = fontInfoAttributesVersion3
+    copyAttributes = set(fontInfoAttributesVersion3)
     copyAttributes.remove("guidelines")
     copyAttributes = tuple(copyAttributes)
 

--- a/Lib/fontParts/base/info.py
+++ b/Lib/fontParts/base/info.py
@@ -7,16 +7,12 @@ from fontParts.base import normalizers
 from fontParts.base.deprecated import DeprecatedInfo
 
 
-_copyAttributes = ()
-if isinstance(fontInfoAttributesVersion3, tuple):
-    _copyAttributes = fontInfoAttributesVersion3
-    _copyAttributes.remove("guidelines")
-    _copyAttributes = tuple(_copyAttributes)
-
 
 class BaseInfo(BaseObject, DeprecatedInfo):
 
-    copyAttributes = _copyAttributes
+    copyAttributes = fontInfoAttributesVersion3
+    copyAttributes.remove("guidelines")
+    copyAttributes = tuple(copyAttributes)
 
     def _reprContents(self):
         contents = []


### PR DESCRIPTION
When making a ``.copy()`` of a font object, not all info attributes would be copied, with the old code the ``font.info.copyAttributes`` would be an empty tuple. I have to admit that I'm not certain if this change breaks any tests, but it seems to do the trick and matches how it looks in other objects.


Sample code:

```python
from fontParts.world import NewFont
from ufoLib import fontInfoAttributesVersion3

f = NewFont()
f.info.unitsPerEm = 200
f.info.postscriptFullName = "Test Font"
print(f.info.unitsPerEm) # 200
print(f.info.postscriptFullName) # "Test Font"

fCopy = f.copy()
print(fCopy.info.unitsPerEm) # None
print(fCopy.info.postscriptFullName) # None

```