### PR TITLE
Add __nonzero__ for py2 and __bool__ for py3 for RImage

### DIFF
--- a/Lib/fontParts/base/image.py
+++ b/Lib/fontParts/base/image.py
@@ -27,23 +27,13 @@ class BaseImage(BaseObject, TransformationMixin):
             contents += self.glyph._reprContents()
         return contents
 
-    # Add a nonzero/bool method for testing if there is image data
-    # otherwise True is always returned
-    PY3 = sys.version_info[0] == 3
-    PY2 = sys.version_info[0] == 2
+    def __bool__(self):
+        if len(self.data) == 0 or self.data == None:
+            return False
+        else:
+            return True
 
-    if PY3:
-        def __bool__(self):
-            if len(self.data) == 0 or self.data == None:
-                return False
-            else:
-                return True
-    else:
-        def __nonzero__(self):
-            if len(self.data) == 0 or self.data == None:
-                return False
-            else:
-                return True
+    __nonzero__ = __bool__
 
     # -------
     # Parents

--- a/Lib/fontParts/base/image.py
+++ b/Lib/fontParts/base/image.py
@@ -1,3 +1,4 @@
+import sys
 import weakref
 from fontTools.misc import transform
 from fontParts.base.errors import FontPartsError
@@ -25,6 +26,24 @@ class BaseImage(BaseObject, TransformationMixin):
             contents.append("in glyph")
             contents += self.glyph._reprContents()
         return contents
+
+    # Add a nonzero/bool method for testing if there is image data
+    # otherwise True is always returned
+    PY3 = sys.version_info[0] == 3
+    PY2 = sys.version_info[0] == 2
+
+    if PY3:
+        def __bool__(self):
+            if len(self.data) == 0 or self.data == None:
+                return False
+            else:
+                return True
+    else:
+        def __nonzero__(self):
+            if len(self.data) == 0 or self.data == None:
+                return False
+            else:
+                return True
 
     # -------
     # Parents

--- a/Lib/fontParts/base/image.py
+++ b/Lib/fontParts/base/image.py
@@ -1,4 +1,3 @@
-import sys
 import weakref
 from fontTools.misc import transform
 from fontParts.base.errors import FontPartsError


### PR DESCRIPTION
This address #61 for py2 and py3. I didn't want to import the builtins object, as I don't have a firm grasp on what that would change in the object model between 2/3, so I did this. I don't know if it's super hacky/tacky or is just fine, so if you have a minute to review @anthrotype, I'd be greatly appreciative. 