### PR TITLE
Adding clear=True to newGlyph

### DIFF
--- a/Lib/fontParts/base/font.py
+++ b/Lib/fontParts/base/font.py
@@ -773,7 +773,7 @@ class BaseFont(_BaseGlyphVendor, DeprecatedFont):
         # clear is False here because the base newFont
         # that has called this method will have already
         # handled the clearing as specified by the caller.
-        return layer.newGlyph(name)
+        return layer.newGlyph(name, clear=False)
 
     def _removeGlyph(self, name, **kwargs):
         """

--- a/Lib/fontParts/base/layer.py
+++ b/Lib/fontParts/base/layer.py
@@ -150,22 +150,31 @@ class _BaseGlyphVendor(BaseObject):
         """
         return name in self.keys()
 
-    def newGlyph(self, name):
+    def newGlyph(self, name, clear=True):
         """
         Make a new glyph with **name** in the layer. ::
 
             >>> glyph = layer.newGlyph("A")
 
         The newly created :class:`BaseGlyph` will be returned.
+        
+        If the glyph exits in the layer, and clear is set to ``False``,
+        the existing glyph will be returned, otherwise the default
+        behavior is to clear the exisiting glyph and return the cleared
+        glyph.
         """
         name = normalizers.normalizeGlyphName(name)
-        if name in self:
+        if name not in self:
+            glyph = self._newGlyph(name)
+        elif clear:
             self.removeGlyph(name)
-        glyph = self._newGlyph(name)
+            glyph = self._newGlyph(name)
+        else:
+            glyph = self._getItem(name)
         self._setLayerInGlyph(glyph)
         return glyph
 
-    def _newGlyph(self, name, **kwargs):
+    def _newGlyph(self, name, clear=True, **kwargs):
         """
         This is the environment implementation of
         :meth:`BaseLayer.newGlyph` and :meth:`BaseFont.newGlyph`

--- a/Lib/fontParts/base/layer.py
+++ b/Lib/fontParts/base/layer.py
@@ -158,10 +158,9 @@ class _BaseGlyphVendor(BaseObject):
 
         The newly created :class:`BaseGlyph` will be returned.
         
-        If the glyph exits in the layer, and clear is set to ``False``,
+        If the glyph exists in the layer and clear is set to ``False``,
         the existing glyph will be returned, otherwise the default
-        behavior is to clear the exisiting glyph and return the cleared
-        glyph.
+        behavior is to clear the exisiting glyph.
         """
         name = normalizers.normalizeGlyphName(name)
         if name not in self:
@@ -174,7 +173,7 @@ class _BaseGlyphVendor(BaseObject):
         self._setLayerInGlyph(glyph)
         return glyph
 
-    def _newGlyph(self, name, clear=True, **kwargs):
+    def _newGlyph(self, name, **kwargs):
         """
         This is the environment implementation of
         :meth:`BaseLayer.newGlyph` and :meth:`BaseFont.newGlyph`


### PR DESCRIPTION
One thing I'm slightly unsure of is setting clear to `False` in font.py (https://github.com/robofab-developers/fontParts/compare/add-clear-to-glyph?expand=1#diff-b6f29e7842d51ccece52b2d48702e219R776). I'm following the comment that was existing there...