### PR TITLE
Adds a mixin to provide the '.position' attribute...

### DIFF
--- a/Lib/fontParts/base/anchor.py
+++ b/Lib/fontParts/base/anchor.py
@@ -2,13 +2,13 @@ import weakref
 from fontTools.misc import transform
 from fontParts.base import normalizers
 from fontParts.base.base import (
-    BaseObject, TransformationMixin, dynamicProperty)
+    BaseObject, TransformationMixin, dynamicProperty, PointPositionMixin)
 from fontParts.base.errors import FontPartsError
 from fontParts.base.color import Color
 from fontParts.base.deprecated import DeprecatedAnchor, RemovedAnchor
 
 
-class BaseAnchor(BaseObject, TransformationMixin, DeprecatedAnchor, RemovedAnchor):
+class BaseAnchor(BaseObject, TransformationMixin, DeprecatedAnchor, RemovedAnchor, PointPositionMixin):
 
     """
     An anchor object. This object is almost always

--- a/Lib/fontParts/base/base.py
+++ b/Lib/fontParts/base/base.py
@@ -496,7 +496,8 @@ class TransformationMixin(object):
         y = math.radians(y)
         t = transform.Identity.skew(x=x, y=y)
         self.transformBy(tuple(t), origin=origin)
-
+        
+        
 
 # -------
 # Helpers
@@ -594,3 +595,28 @@ class dynamicProperty(object):
 
 def interpolate(a, b, v):
     return a + (b - a) * v
+    
+
+
+class PointPositionMixin(object):
+
+    position = dynamicProperty("base_position", "The point position.")
+
+    def _get_base_position(self):
+        value = self._get_position()
+        value = normalizers.normalizeCoordinateTuple(value)
+        return value
+
+    def _set_base_position(self, value):
+        value = normalizers.normalizeCoordinateTuple(value)
+        self._set_position(value)
+
+    def _get_position(self):
+        return (self.x, self.y)
+
+    def _set_position(self, value):
+        pX, pY = self.position
+        x, y = value
+        dX = x - pX
+        dY = y - pY
+        self.moveBy((dX, dY))

--- a/Lib/fontParts/base/base.py
+++ b/Lib/fontParts/base/base.py
@@ -599,6 +599,12 @@ def interpolate(a, b, v):
 
 
 class PointPositionMixin(object):
+    
+    """
+    This adds a ``position`` attribute as a dyanmicProperty,
+    for use as a mixin with objects that have ``x`` and ``y`` 
+    attributes.
+    """
 
     position = dynamicProperty("base_position", "The point position.")
 
@@ -612,9 +618,15 @@ class PointPositionMixin(object):
         self._set_position(value)
 
     def _get_position(self):
+        """
+        Subclasses may override this method.
+        """
         return (self.x, self.y)
 
     def _set_position(self, value):
+        """
+        Subclasses may override this method.
+        """
         pX, pY = self.position
         x, y = value
         dX = x - pX

--- a/Lib/fontParts/base/component.py
+++ b/Lib/fontParts/base/component.py
@@ -3,11 +3,11 @@ from fontTools.misc import transform
 from fontParts.base import normalizers
 from fontParts.base.errors import FontPartsError
 from fontParts.base.base import (
-    BaseObject, TransformationMixin, dynamicProperty)
+    BaseObject, TransformationMixin, dynamicProperty, PointPositionMixin)
 from fontParts.base.deprecated import DeprecatedComponent, RemovedComponent
 
 
-class BaseComponent(BaseObject, TransformationMixin, DeprecatedComponent, RemovedComponent):
+class BaseComponent(BaseObject, TransformationMixin, DeprecatedComponent, RemovedComponent, PointPositionMixin):
 
     copyAttributes = (
         "baseGlyph",

--- a/Lib/fontParts/base/deprecated.py
+++ b/Lib/fontParts/base/deprecated.py
@@ -127,18 +127,6 @@ class RemovedAnchor(RemovedBase):
 
 class DeprecatedAnchor(DeprecatedBase, DeprecatedTransformation):
 
-    def _get_position(self):
-        warnings.warn("'Anchor.position': use Anchor.x, Anchor.y", DeprecationWarning)
-        return self.x, self.y
-
-    def _set_position(self, position):
-        warnings.warn("'Anchor.position': use Anchor.x, Anchor.y", DeprecationWarning)
-        x, y = position
-        self.x = x
-        self.y = y
-
-    position = property(_get_position, _set_position, doc="Deprecated Anchor.position")
-
     def _generateIdentifier(self):
         warnings.warn("'Anchor._generateIdentifier()': use 'Anchor._getIdentifier()'", DeprecationWarning)
         return self._getIdentifier()

--- a/Lib/fontParts/base/guideline.py
+++ b/Lib/fontParts/base/guideline.py
@@ -3,13 +3,13 @@ import weakref
 from fontTools.misc import transform
 from fontParts.base.errors import FontPartsError
 from fontParts.base.base import (
-    BaseObject, TransformationMixin, dynamicProperty)
+    BaseObject, TransformationMixin, dynamicProperty, PointPositionMixin)
 from fontParts.base import normalizers
 from fontParts.base.color import Color
 from fontParts.base.deprecated import DeprecatedGuideline, RemovedGuideline
 
 
-class BaseGuideline(BaseObject, TransformationMixin, DeprecatedGuideline, RemovedGuideline):
+class BaseGuideline(BaseObject, TransformationMixin, DeprecatedGuideline, RemovedGuideline, PointPositionMixin):
 
     """
     A guideline object. This object is almost always

--- a/Lib/fontParts/base/image.py
+++ b/Lib/fontParts/base/image.py
@@ -2,12 +2,12 @@ import weakref
 from fontTools.misc import transform
 from fontParts.base.errors import FontPartsError
 from fontParts.base.base import (
-    BaseObject, TransformationMixin, dynamicProperty)
+    BaseObject, TransformationMixin, dynamicProperty, PointPositionMixin)
 from fontParts.base import normalizers
 from fontParts.base.color import Color
 
 
-class BaseImage(BaseObject, TransformationMixin):
+class BaseImage(BaseObject, TransformationMixin, PointPositionMixin):
 
     copyAttributes = (
         "transformation",

--- a/Lib/fontParts/base/point.py
+++ b/Lib/fontParts/base/point.py
@@ -1,12 +1,12 @@
 import weakref
 from fontTools.misc import transform
 from fontParts.base.base import (
-    BaseObject, TransformationMixin, dynamicProperty)
+    BaseObject, TransformationMixin, dynamicProperty, PointPositionMixin)
 from fontParts.base import normalizers
 from fontParts.base.deprecated import DeprecatedPoint, RemovedPoint
 
 
-class BasePoint(BaseObject, TransformationMixin, DeprecatedPoint, RemovedPoint):
+class BasePoint(BaseObject, TransformationMixin, DeprecatedPoint, RemovedPoint, PointPositionMixin):
 
     """
     A point object. This object is almost always


### PR DESCRIPTION
... for objects that have '.x' and '.y' attributes (anchor, point, component, guideline, image)

I modeled it after the bPoint.anchor's dynamicProperty, so I hope this looks like it fits with the style. Let me know if there are any comments!