### PR TITLE
Adding __hash__ and __eq__ to objects (#118)

### DIFF
--- a/Lib/fontParts/base/bPoint.py
+++ b/Lib/fontParts/base/bPoint.py
@@ -22,7 +22,7 @@ class BaseBPoint(BaseObject, TransformationMixin, DeprecatedBPoint, RemovedBPoin
     def __eq__(self, other):
         if hasattr(other, "_point"):
             return self._point == other._point
-        return False
+        return NotImplemented
 
     # -------
     # Parents

--- a/Lib/fontParts/base/base.py
+++ b/Lib/fontParts/base/base.py
@@ -52,6 +52,31 @@ class BaseObject(object):
         """
         return []
 
+    # --------
+    # equality
+    # --------
+
+    def __eq__(self, other):
+        """
+        Subclasses may override this method.
+        """
+        if isinstance(other, self.__class__):
+            return self.naked() is other.naked()
+        return NotImplemented
+
+    def __ne__(self, other):
+        """
+        Subclasses must not override this method.
+        """
+        equal = self.__eq__(other)
+        return NotImplemented if equal is NotImplemented else not equal
+
+    # ----
+    # Hash
+    # ----
+    
+    __hash__ = None
+
     # ----
     # Copy
     # ----

--- a/Lib/fontParts/base/font.py
+++ b/Lib/fontParts/base/font.py
@@ -2,7 +2,7 @@ import os
 import fontMath
 from fontTools.misc.py23 import basestring
 from fontParts.base.errors import FontPartsError
-from fontParts.base.base import BaseObject, dynamicProperty
+from fontParts.base.base import dynamicProperty
 from fontParts.base.layer import _BaseGlyphVendor
 from fontParts.base import normalizers
 from fontParts.base.deprecated import DeprecatedFont, RemovedFont
@@ -38,6 +38,15 @@ class BaseFont(_BaseGlyphVendor, DeprecatedFont, RemovedFont):
         if self.path is not None:
             contents.append("path=%r" % self.path)
         return contents
+
+    def __hash__(self):
+        """
+        Allow font object to be used as a key
+        in a dictionary.
+        
+        Subclasses may override this method.
+        """
+        return id(self.naked())
 
     # ----
     # Copy

--- a/Lib/fontParts/base/glyph.py
+++ b/Lib/fontParts/base/glyph.py
@@ -35,6 +35,15 @@ class BaseGlyph(BaseObject, TransformationMixin, DeprecatedGlyph, RemovedGlyph):
             contents.append("('%s')" % self.layer.name)
         return contents
 
+    def __hash__(self):
+        """
+        Allow glyph object to be used as a key
+        in a dictionary.
+        
+        Subclasses may override this method.
+        """
+        return id(self.naked())
+
     def copy(self):
         """
         Copy the glyph into a new glyph that does not

--- a/Lib/fontParts/base/segment.py
+++ b/Lib/fontParts/base/segment.py
@@ -11,11 +11,6 @@ class BaseSegment(BaseObject, TransformationMixin, DeprecatedSegment, RemovedSeg
         assert not hasattr(self, "_points")
         self._points = points
 
-    def __eq__(self, other):
-        if hasattr(other, "points"):
-            return self.points == other.points
-        return False
-
     def _reprContents(self):
         contents = [
             "%s" % self.type,
@@ -23,6 +18,11 @@ class BaseSegment(BaseObject, TransformationMixin, DeprecatedSegment, RemovedSeg
         if self.index is not None:
             contents.append("index='%r'" % self.index)
         return contents
+
+    def __eq__(self, other):
+        if hasattr(other, "points"):
+            return self.points == other.points
+        return NotImplemented
 
     # -------
     # Parents

--- a/Lib/fontParts/nonelab/base.py
+++ b/Lib/fontParts/nonelab/base.py
@@ -8,11 +8,6 @@ class RBaseObject(object):
         if wrap is not None:
             self._wrapped = wrap
 
-    def __eq__(self, other):
-        if hasattr(other, "_wrapped"):
-            return self._wrapped == other._wrapped
-        return False
-
     def naked(self):
         if hasattr(self, "_wrapped"):
             return self._wrapped

--- a/Lib/fontParts/test/test_anchor.py
+++ b/Lib/fontParts/test/test_anchor.py
@@ -1,4 +1,5 @@
 import unittest
+import collections
 from fontParts.base import FontPartsError
 from fontParts.base.deprecated import RemovedWarning
 from fontTools.misc.py23 import basestring
@@ -264,9 +265,45 @@ class TestAnchor(unittest.TestCase):
         anchor = glyph.anchors[0]
         with self.assertRaises(RemovedWarning):
             anchor.draw(pen)
+
     def test_drawPoints(self):
         glyph, unrequested = self.getAnchor_index()
         pen = glyph.getPen()
         anchor = glyph.anchors[0]
         with self.assertRaises(RemovedWarning):
             anchor.drawPoints(pen)
+
+    # ----
+    # Hash
+    # ----
+    def test_hash(self):
+        anchor, unrequested = self.getAnchor_generic()
+        self.assertEqual(
+            isinstance(anchor, collections.Hashable),
+            False
+        )
+
+    # --------
+    # Equality
+    # --------
+
+    def test_equal(self):
+        anchor_one, unrequested = self.getAnchor_generic()
+        anchor_two, unrequested = self.getAnchor_generic()
+        self.assertEqual(
+            anchor_one,
+            anchor_one
+        )
+        self.assertNotEqual(
+            anchor_one,
+            anchor_two
+        )
+        a = anchor_one
+        self.assertEqual(
+            anchor_one,
+            a
+        )
+        self.assertNotEqual(
+            anchor_two,
+            a
+        )

--- a/Lib/fontParts/test/test_bPoint.py
+++ b/Lib/fontParts/test/test_bPoint.py
@@ -1,4 +1,5 @@
 import unittest
+import collections
 from fontParts.base import FontPartsError
 
 
@@ -22,4 +23,75 @@ class TestBPoint(unittest.TestCase):
         self.assertEqual(
             bPoint.type,
             "corner"
+        )
+        bPoint.type = "curve"
+        self.assertEqual(
+            bPoint.type,
+            "curve"
+        )
+        self.assertNotEqual(
+            bPoint.type,
+            "corner"
+        )
+
+    # ------
+    # Anchor
+    # ------
+
+    def test_anchor(self):
+        bPoint, unrequested = self.getBPoint_corner()
+        self.assertEqual(
+            bPoint.anchor,
+            (101, 202)
+        )
+        bPoint.anchor = (51,45)
+        self.assertEqual(
+            bPoint.anchor,
+            (51, 45)
+        )
+
+    # -----
+    # Index
+    # -----
+
+    def test_index(self):
+        bPoint, unrequested = self.getBPoint_corner()
+        self.assertEqual(
+            bPoint.index,
+            1
+        )
+
+    # ----
+    # Hash
+    # ----
+    def test_hash(self):
+        bPoint, unrequested = self.getBPoint_corner()
+        self.assertEqual(
+            isinstance(bPoint, collections.Hashable),
+            False
+        )
+
+    # --------
+    # Equality
+    # --------
+
+    def test_equal(self):
+        bPoint_one, unrequested = self.getBPoint_corner()
+        bPoint_two, unrequested = self.getBPoint_corner()
+        self.assertEqual(
+            bPoint_one,
+            bPoint_one
+        )
+        self.assertNotEqual(
+            bPoint_one,
+            bPoint_two
+        )
+        a = bPoint_one
+        self.assertEqual(
+            bPoint_one,
+            a
+        )
+        self.assertNotEqual(
+            bPoint_two,
+            a
         )

--- a/Lib/fontParts/test/test_component.py
+++ b/Lib/fontParts/test/test_component.py
@@ -1,4 +1,5 @@
 import unittest
+import collections
 from fontParts.base import FontPartsError
 
 
@@ -75,3 +76,38 @@ class TestComponent(unittest.TestCase):
         # set
         with self.assertRaises(FontPartsError):
             component.bounds = (0, 0, 100, 100)
+
+    # ----
+    # Hash
+    # ----
+    def test_hash(self):
+        component, unrequested = self.getComponent_generic()
+        self.assertEqual(
+            isinstance(component, collections.Hashable),
+            False
+        )
+
+    # --------
+    # Equality
+    # --------
+
+    def test_equal(self):
+        component_one, unrequested = self.getComponent_generic()
+        component_two, unrequested = self.getComponent_generic()
+        self.assertEqual(
+            component_one,
+            component_one
+        )
+        self.assertNotEqual(
+            component_one,
+            component_two
+        )
+        a = component_one
+        self.assertEqual(
+            component_one,
+            a
+        )
+        self.assertNotEqual(
+            component_two,
+            a
+        )

--- a/Lib/fontParts/test/test_contour.py
+++ b/Lib/fontParts/test/test_contour.py
@@ -1,4 +1,5 @@
 import unittest
+import collections
 from fontParts.base import FontPartsError
 
 
@@ -49,3 +50,38 @@ class TestContour(unittest.TestCase):
         # set
         with self.assertRaises(FontPartsError):
             contour.bounds = (1, 2, 3, 4)
+
+    # ----
+    # Hash
+    # ----
+    def test_hash(self):
+        contour, unrequested = self.getContour_bounds()
+        self.assertEqual(
+            isinstance(contour, collections.Hashable),
+            False
+        )
+
+    # --------
+    # Equality
+    # --------
+
+    def test_equal(self):
+        contour_one, unrequested = self.getContour_bounds()
+        contour_two, unrequested = self.getContour_bounds()
+        self.assertEqual(
+            contour_one,
+            contour_one
+        )
+        self.assertNotEqual(
+            contour_one,
+            contour_two
+        )
+        a = contour_one
+        self.assertEqual(
+            contour_one,
+            a
+        )
+        self.assertNotEqual(
+            contour_two,
+            a
+        )

--- a/Lib/fontParts/test/test_features.py
+++ b/Lib/fontParts/test/test_features.py
@@ -1,4 +1,5 @@
 import unittest
+import collections
 from fontParts.base import FontPartsError
 
 
@@ -31,3 +32,38 @@ class TestFeatures(unittest.TestCase):
         # set: invalid
         with self.assertRaises(FontPartsError):
             features.text = 123
+
+    # ----
+    # Hash
+    # ----
+    def test_hash(self):
+        features, unrequested = self.getFeatures_generic()
+        self.assertEqual(
+            isinstance(features, collections.Hashable),
+            False
+        )
+
+    # --------
+    # Equality
+    # --------
+
+    def test_equal(self):
+        features_one, unrequested = self.getFeatures_generic()
+        features_two, unrequested = self.getFeatures_generic()
+        self.assertEqual(
+            features_one,
+            features_one
+        )
+        self.assertNotEqual(
+            features_one,
+            features_two
+        )
+        a = features_one
+        self.assertEqual(
+            features_one,
+            a
+        )
+        self.assertNotEqual(
+            features_two,
+            a
+        )

--- a/Lib/fontParts/test/test_font.py
+++ b/Lib/fontParts/test/test_font.py
@@ -1,4 +1,5 @@
 import unittest
+import collections
 from fontParts.base import FontPartsError
 
 
@@ -29,4 +30,58 @@ class TestFont(unittest.TestCase):
         self.assertEqual(
             len(font),
             4
+        )
+
+    # ----
+    # Hash
+    # ----
+
+    def test_hash(self):
+        font_one, unrequested = self.getFont_glyphs()
+        font_two, unrequested = self.getFont_glyphs()
+        self.assertEqual(
+            hash(font_one),
+            hash(font_one)
+        )
+        self.assertNotEqual(
+            hash(font_one),
+            hash(font_two)
+        )
+        a = font_one
+        self.assertEqual(
+            hash(font_one),
+            hash(a)
+        )
+        self.assertNotEqual(
+            hash(font_two),
+            hash(a)
+        )
+        self.assertEqual(
+            isinstance(font_one, collections.Hashable),
+            True
+        )
+
+    # --------
+    # Equality
+    # --------
+
+    def test_equal(self):
+        font_one, unrequested = self.getFont_glyphs()
+        font_two, unrequested = self.getFont_glyphs()
+        self.assertEqual(
+            font_one,
+            font_one
+        )
+        self.assertNotEqual(
+            font_one,
+            font_two
+        )
+        a = font_one
+        self.assertEqual(
+            font_one,
+            a
+        )
+        self.assertNotEqual(
+            font_two,
+            a
         )

--- a/Lib/fontParts/test/test_glyph.py
+++ b/Lib/fontParts/test/test_glyph.py
@@ -1,4 +1,5 @@
 import unittest
+import collections
 from fontParts.base import FontPartsError
 
 
@@ -49,3 +50,65 @@ class TestGlyph(unittest.TestCase):
             glyph.width = "abc"
         with self.assertRaises(FontPartsError):
             glyph.width = None
+
+    # ----
+    # Hash
+    # ----
+
+    def test_hash(self):
+        glyph_one, unrequested = self.getGlyph_generic()
+        glyph_two, unrequested = self.getGlyph_generic()
+        glyph_one.name = "Test"
+        self.assertEqual(
+            hash(glyph_one),
+            hash(glyph_one)
+        )
+        glyph_two.name = "Test"
+        self.assertNotEqual(
+            hash(glyph_one),
+            hash(glyph_two)
+        )
+        a = glyph_one
+        self.assertEqual(
+            hash(glyph_one),
+            hash(a)
+        )
+        self.assertNotEqual(
+            hash(glyph_two),
+            hash(a)
+        )
+        self.assertEqual(
+            isinstance(glyph_one, collections.Hashable),
+            True
+        )
+
+    # --------
+    # Equality
+    # --------
+
+    def test_equal(self):
+        glyph_one, unrequested = self.getGlyph_generic()
+        glyph_two, unrequested = self.getGlyph_generic()
+        glyph_one.name = "Test"
+        self.assertEqual(
+            glyph_one,
+            glyph_one
+        )
+        self.assertNotEqual(
+            glyph_one,
+            glyph_two
+        )
+        glyph_two.name = "Test"
+        self.assertNotEqual(
+            glyph_one,
+            glyph_two
+        )
+        a = glyph_one
+        self.assertEqual(
+            glyph_one,
+            a
+        )
+        self.assertNotEqual(
+            glyph_two,
+            a
+        )

--- a/Lib/fontParts/test/test_groups.py
+++ b/Lib/fontParts/test/test_groups.py
@@ -1,4 +1,5 @@
 import unittest
+import collections
 from fontParts.base import FontPartsError
 
 
@@ -49,3 +50,38 @@ class TestGroups(unittest.TestCase):
         # find: invalid
         with self.assertRaises(FontPartsError):
             groups.findGlyph(5)
+
+    # ----
+    # Hash
+    # ----
+    def test_hash(self):
+        groups, unrequested = self.getGroups_generic()
+        self.assertEqual(
+            isinstance(groups, collections.Hashable),
+            False
+        )
+
+    # --------
+    # Equality
+    # --------
+
+    def test_equal(self):
+        groups_one, unrequested = self.getGroups_generic()
+        groups_two, unrequested = self.getGroups_generic()
+        self.assertEqual(
+            groups_one,
+            groups_one
+        )
+        self.assertNotEqual(
+            groups_one,
+            groups_two
+        )
+        a = groups_one
+        self.assertEqual(
+            groups_one,
+            a
+        )
+        self.assertNotEqual(
+            groups_two,
+            a
+        )

--- a/Lib/fontParts/test/test_guideline.py
+++ b/Lib/fontParts/test/test_guideline.py
@@ -1,4 +1,5 @@
 import unittest
+import collections
 from fontParts.base import FontPartsError
 
 
@@ -51,3 +52,38 @@ class TestGuideline(unittest.TestCase):
         # set: invalid
         with self.assertRaises(FontPartsError):
             guideline.x = "ABC"
+
+    # ----
+    # Hash
+    # ----
+    def test_hash(self):
+        guideline, unrequested = self.getGuideline_generic()
+        self.assertEqual(
+            isinstance(guideline, collections.Hashable),
+            False
+        )
+
+    # --------
+    # Equality
+    # --------
+
+    def test_equal(self):
+        guideline_one, unrequested = self.getGuideline_generic()
+        guideline_two, unrequested = self.getGuideline_generic()
+        self.assertEqual(
+            guideline_one,
+            guideline_one
+        )
+        self.assertNotEqual(
+            guideline_one,
+            guideline_two
+        )
+        a = guideline_one
+        self.assertEqual(
+            guideline_one,
+            a
+        )
+        self.assertNotEqual(
+            guideline_two,
+            a
+        )

--- a/Lib/fontParts/test/test_image.py
+++ b/Lib/fontParts/test/test_image.py
@@ -1,4 +1,5 @@
 import unittest
+import collections
 from fontParts.base import FontPartsError
 
 
@@ -284,3 +285,38 @@ class TestImage(unittest.TestCase):
         # set: invalid
         with self.assertRaises(FontPartsError):
             image.data = 123
+
+    # ----
+    # Hash
+    # ----
+    def test_hash(self):
+        image, unrequested = self.getImage_generic()
+        self.assertEqual(
+            isinstance(image, collections.Hashable),
+            False
+        )
+
+    # --------
+    # Equality
+    # --------
+
+    def test_equal(self):
+        image_one, unrequested = self.getImage_generic()
+        image_two, unrequested = self.getImage_generic()
+        self.assertEqual(
+            image_one,
+            image_one
+        )
+        self.assertNotEqual(
+            image_one,
+            image_two
+        )
+        a = image_one
+        self.assertEqual(
+            image_one,
+            a
+        )
+        self.assertNotEqual(
+            image_two,
+            a
+        )

--- a/Lib/fontParts/test/test_info.py
+++ b/Lib/fontParts/test/test_info.py
@@ -1,4 +1,5 @@
 import unittest
+import collections
 from fontParts.base import FontPartsError
 
 
@@ -36,3 +37,38 @@ class TestInfo(unittest.TestCase):
             info.unitsPerEm = -1000
         with self.assertRaises(FontPartsError):
             info.unitsPerEm = "abc"
+
+    # ----
+    # Hash
+    # ----
+    def test_hash(self):
+        info, unrequested = self.getInfo_generic()
+        self.assertEqual(
+            isinstance(info, collections.Hashable),
+            False
+        )
+
+    # --------
+    # Equality
+    # --------
+
+    def test_equal(self):
+        info_one, unrequested = self.getInfo_generic()
+        info_two, unrequested = self.getInfo_generic()
+        self.assertEqual(
+            info_one,
+            info_one
+        )
+        self.assertNotEqual(
+            info_one,
+            info_two
+        )
+        a = info_one
+        self.assertEqual(
+            info_one,
+            a
+        )
+        self.assertNotEqual(
+            info_two,
+            a
+        )

--- a/Lib/fontParts/test/test_kerning.py
+++ b/Lib/fontParts/test/test_kerning.py
@@ -1,4 +1,5 @@
 import unittest
+import collections
 from fontParts.base import FontPartsError
 
 
@@ -149,4 +150,39 @@ class TestKerning(unittest.TestCase):
         self.assertEqual(
             len(kerning),
             0
+        )
+
+    # ----
+    # Hash
+    # ----
+    def test_hash(self):
+        kerning, unrequested = self.getKerning_generic()
+        self.assertEqual(
+            isinstance(kerning, collections.Hashable),
+            False
+        )
+
+    # --------
+    # Equality
+    # --------
+
+    def test_equal(self):
+        kerning_one, unrequested = self.getKerning_generic()
+        kerning_two, unrequested = self.getKerning_generic()
+        self.assertEqual(
+            kerning_one,
+            kerning_one
+        )
+        self.assertNotEqual(
+            kerning_one,
+            kerning_two
+        )
+        a = kerning_one
+        self.assertEqual(
+            kerning_one,
+            a
+        )
+        self.assertNotEqual(
+            kerning_two,
+            a
         )

--- a/Lib/fontParts/test/test_layer.py
+++ b/Lib/fontParts/test/test_layer.py
@@ -1,4 +1,5 @@
 import unittest
+import collections
 from fontParts.base import FontPartsError
 
 
@@ -21,4 +22,39 @@ class TestLayer(unittest.TestCase):
         self.assertEqual(
             len(layer),
             4
+        )
+
+    # ----
+    # Hash
+    # ----
+    def test_hash(self):
+        layer, unrequested = self.getLayer_glyphs()
+        self.assertEqual(
+            isinstance(layer, collections.Hashable),
+            False
+        )
+
+    # --------
+    # Equality
+    # --------
+
+    def test_equal(self):
+        layer_one, unrequested = self.getLayer_glyphs()
+        layer_two, unrequested = self.getLayer_glyphs()
+        self.assertEqual(
+            layer_one,
+            layer_one
+        )
+        self.assertNotEqual(
+            layer_one,
+            layer_two
+        )
+        a = layer_one
+        self.assertEqual(
+            layer_one,
+            a
+        )
+        self.assertNotEqual(
+            layer_two,
+            a
         )

--- a/Lib/fontParts/test/test_point.py
+++ b/Lib/fontParts/test/test_point.py
@@ -1,4 +1,5 @@
 import unittest
+import collections
 from fontParts.base import FontPartsError
 
 
@@ -52,3 +53,38 @@ class TestPoint(unittest.TestCase):
             point.type = "xxx"
         with self.assertRaises(FontPartsError):
             point.type = 123
+
+    # ----
+    # Hash
+    # ----
+    def test_hash(self):
+        point, unrequested = self.getPoint_generic()
+        self.assertEqual(
+            isinstance(point, collections.Hashable),
+            False
+        )
+
+    # --------
+    # Equality
+    # --------
+
+    def test_equal(self):
+        point_one, unrequested = self.getPoint_generic()
+        point_two, unrequested = self.getPoint_generic()
+        self.assertEqual(
+            point_one,
+            point_one
+        )
+        self.assertNotEqual(
+            point_one,
+            point_two
+        )
+        a = point_one
+        self.assertEqual(
+            point_one,
+            a
+        )
+        self.assertNotEqual(
+            point_two,
+            a
+        )

--- a/Lib/fontParts/test/test_segment.py
+++ b/Lib/fontParts/test/test_segment.py
@@ -1,4 +1,5 @@
 import unittest
+import collections
 from fontParts.base import FontPartsError
 
 
@@ -89,3 +90,39 @@ class TestSegment(unittest.TestCase):
             segment.type = "xxx"
         with self.assertRaises(FontPartsError):
             segment.type = 123
+
+
+    # ----
+    # Hash
+    # ----
+    def test_hash(self):
+        segment, unrequested = self.getSegment_line()
+        self.assertEqual(
+            isinstance(segment, collections.Hashable),
+            False
+        )
+
+    # --------
+    # Equality
+    # --------
+
+    def test_equal(self):
+        segment_one, unrequested = self.getSegment_line()
+        segment_two, unrequested = self.getSegment_line()
+        self.assertEqual(
+            segment_one,
+            segment_one
+        )
+        self.assertNotEqual(
+            segment_one,
+            segment_two
+        )
+        a = segment_one
+        self.assertEqual(
+            segment_one,
+            a
+        )
+        self.assertNotEqual(
+            segment_two,
+            a
+        )

--- a/documentation/source/environments/index.rst
+++ b/documentation/source/environments/index.rst
@@ -109,10 +109,20 @@ Each of these require their own specific environment overrides, but the general 
         # It must return a boolean indicating if the lower level
         # objects are the same object. This does not mean that two
         # objects that have the same content should be considered
-        # equal. It means that the object must be the same.
+        # equal. It means that the object must be the same. The 
+        # corrilary __ne__ also needs to be defined for Python 2.7.
+        # It is not necessary for a Python 3.
+        #
+        # Note that the base implentation of fontParts provides
+        # __eq__ and __ne__ methods that test the naked objects 
+        # for equality. Depending on environmental needs this can 
+        # be overridden.
 
         def __eq__(self, other):
             return self.myObj == other.myObj
+
+        def __ne__(self, other):
+            return self.myObj != other.myObj
 
         # Properties.
         # Properties are get and set through standard method names.


### PR DESCRIPTION
* Add __hash__ and __eq__ from discustion in #52

* font doesn't seem to use BaseObject (it's pulled in via _BaseGlyphVendor)

* Add tests for all objects. Define hash for bPoint and segment. Add note that subclasses can override the default

* Remove the __eq__ from nonelab base.

* Adding __ne__ for Python 2, adding more tests, and separated the hash tests from the equality tests

* add __ne__ to environmental documentation, and a note that the base classes have these available as tests to the naked objects.

* If object can't compare, return `NotImpemented`. Improve the hash return of bPoint and segment to match values of equality testing. Move segment tests to a more logical spot in the file.

* Remove hash. Make __ne__ reflect Python 3 behavior (thank you @anthrotype) and state that subclasses must not override this method. Remove hash and __ne__ from bPoint and segment

* Add hash to font and glyph so they can be used as dictionary keys. Update tests.

* Set hash to  `None` for python 2.7. Add test to double check that things intented not to be hashable are so.