### PR TITLE
Refactor tests

### DIFF
--- a/Lib/fontParts/test/test_anchor.py
+++ b/Lib/fontParts/test/test_anchor.py
@@ -131,7 +131,7 @@ class TestAnchor(unittest.TestCase):
     # -------
 
     def getAnchor_copy(self):
-        anchor, _unrequested = self.getAnchor_generic()
+        anchor = self.getAnchor_generic()
         anchor.color = (0.1, 0.2, 0.3, 0.4)
         return anchor
 
@@ -244,7 +244,7 @@ class TestAnchor(unittest.TestCase):
         self.assertEqual(anchor.y, 2)
 
     def getAnchor_round(self):
-        anchor, _unrequested = self.getAnchor_generic()
+        anchor = self.getAnchor_generic()
         anchor.x = 1.1
         anchor.y = 2.5
         return anchor

--- a/Lib/fontParts/test/test_anchor.py
+++ b/Lib/fontParts/test/test_anchor.py
@@ -370,12 +370,11 @@ class TestAnchor(unittest.TestCase):
 
     def test_object_equal_self(self):
         anchor_one = self.getAnchor_generic()
-        anchor_two = self.getAnchor_generic()
         self.assertEqual(
             anchor_one,
             anchor_one
         )
-    def test_object_notequal_other(self):
+    def test_object_not_equal_other(self):
         anchor_one = self.getAnchor_generic()
         anchor_two = self.getAnchor_generic()
         self.assertNotEqual(
@@ -384,13 +383,13 @@ class TestAnchor(unittest.TestCase):
         )
     def test_object_equal_variable_assignment_self(self):
         anchor_one = self.getAnchor_generic()
-        anchor_two = self.getAnchor_generic()
         a = anchor_one
+        a.moveBy((-1, 2))
         self.assertEqual(
             anchor_one,
             a
         )
-    def test_object_notequal_variable_assignment_other(self):
+    def test_object_not_equal_variable_assignment_other(self):
         anchor_one = self.getAnchor_generic()
         anchor_two = self.getAnchor_generic()
         a = anchor_one

--- a/Lib/fontParts/test/test_anchor.py
+++ b/Lib/fontParts/test/test_anchor.py
@@ -19,56 +19,76 @@ class TestAnchor(unittest.TestCase):
     # Attributes
     # ----------
 
-    def test_name(self):
+    def test_get(self):
         anchor = self.getAnchor_generic()
-        # get
         self.assertEqual(anchor.name, "Anchor Attribute Test")
-        # set: valid
+    def test_set_valid(self):
+        anchor = self.getAnchor_generic()
         anchor.name = u"foo"
         self.assertEqual(anchor.name, u"foo")
-        # set: None
+    def test_set_none(self):
+        anchor = self.getAnchor_generic()
         anchor.name = None
         self.assertIsNone(anchor.name)
-        # set: invalid
+    def test_set_invalid(self):
+        anchor = self.getAnchor_generic()
         with self.assertRaises(FontPartsError):
             anchor.name = 123
 
-    def test_color(self):
+    def test_color_get_none(self):
         anchor = self.getAnchor_generic()
-        # get
         self.assertIsNone(anchor.color)
-        # set: valid
+    def test_color_set_valid_max(self):
+        anchor = self.getAnchor_generic()
         anchor.color = (1, 1, 1, 1)
         self.assertEqual(anchor.color, (1, 1, 1, 1))
+    def test_color_set_valid_min(self):
+        anchor = self.getAnchor_generic()
         anchor.color = (0, 0, 0, 0)
         self.assertEqual(anchor.color, (0, 0, 0, 0))
+    def test_color_set_valid_decimal(self):
+        anchor = self.getAnchor_generic()
         anchor.color = (0.1, 0.2, 0.3, 0.4)
         self.assertEqual(anchor.color, (0.1, 0.2, 0.3, 0.4))
-        # set: None
+    def test_color_set_none(self):
+        anchor = self.getAnchor_generic()
         anchor.color = None
         self.assertIsNone(anchor.color)
-        # set: invalid
+    def test_color_set_invalid_over_max(self):
+        anchor = self.getAnchor_generic()
         with self.assertRaises(FontPartsError):
             anchor.color = (1.1, 0.2, 0.3, 0.4)
+    def test_color_set_invalid_uner_min(self):
+        anchor = self.getAnchor_generic()
         with self.assertRaises(FontPartsError):
             anchor.color = (-0.1, 0.2, 0.3, 0.4)
+    def test_color_set_invalid_too_few(self):
+        anchor = self.getAnchor_generic()
         with self.assertRaises(FontPartsError):
             anchor.color = (0.1, 0.2, 0.3)
+    def test_color_set_invalid_string(self):
+        anchor = self.getAnchor_generic()
         with self.assertRaises(FontPartsError):
             anchor.color = "0.1,0.2,0.3,0.4"
+    def test_color_set_invalid_int(self):
+        anchor = self.getAnchor_generic()
         with self.assertRaises(FontPartsError):
             anchor.color = 123
 
-    def test_identifier(self):
+    def test_identifier_get_none(self):
         anchor = self.getAnchor_generic()
-        # get
         self.assertIsNone(anchor.identifier)
-        # get
+    def test_identifier_generated_type(self):
+        anchor = self.getAnchor_generic()
         anchor.generateIdentifier()
         self.assertIsInstance(anchor.identifier, basestring)
+    def test_identifier_consistencey(self):
+        anchor = self.getAnchor_generic()
+        anchor.generateIdentifier()
         # get: twice to test consistency
         self.assertEqual(anchor.identifier, anchor.identifier)
-        # set
+    def test_identifier_cannot_set(self):
+        anchor = self.getAnchor_generic()
         with self.assertRaises(FontPartsError):
             anchor.identifier = "ABC"
 
@@ -84,45 +104,67 @@ class TestAnchor(unittest.TestCase):
         for i, anchor in enumerate(glyph.anchors):
             self.assertEqual(anchor.index, i)
 
-    def test_x(self):
+    def test_x_get(self):
         anchor = self.getAnchor_generic()
-        # get
         self.assertEqual(anchor.x, 1)
-        # set: valid
+    def test_x_set_valid_positive(self):
+        anchor = self.getAnchor_generic()
         anchor.x = 100
         self.assertEqual(anchor.x, 100)
+    def test_x_set_valid_negative(self):
+        anchor = self.getAnchor_generic()
         anchor.x = -100
         self.assertEqual(anchor.x, -100)
+    def test_x_set_valid_zero(self):
+        anchor = self.getAnchor_generic()
         anchor.x = 0
         self.assertEqual(anchor.x, 0)
+    def test_x_set_valid_positive_decimal(self):
+        anchor = self.getAnchor_generic()
         anchor.x = 1.1
         self.assertEqual(anchor.x, 1.1)
+    def test_x_set_valid_negative_decimal(self):
+        anchor = self.getAnchor_generic()
         anchor.x = -1.1
         self.assertEqual(anchor.x, -1.1)
-        # set: invalid
+    def test_x_set_invalid_none(self):
+        anchor = self.getAnchor_generic()
         with self.assertRaises(FontPartsError):
             anchor.x = None
+    def test_x_set_valid_string(self):
+        anchor = self.getAnchor_generic()
         with self.assertRaises(FontPartsError):
             anchor.x = "ABC"
 
-    def test_y(self):
+    def test_y_get(self):
         anchor = self.getAnchor_generic()
-        # get
         self.assertEqual(anchor.y, 2)
-        # set: valid
-        anchor.y = 200
-        self.assertEqual(anchor.y, 200)
-        anchor.y = -200
-        self.assertEqual(anchor.y, -200)
+    def test_y_set_valid_positive(self):
+        anchor = self.getAnchor_generic()
+        anchor.y = 100
+        self.assertEqual(anchor.y, 100)
+    def test_y_set_valid_negative(self):
+        anchor = self.getAnchor_generic()
+        anchor.y = -100
+        self.assertEqual(anchor.y, -100)
+    def test_y_set_valid_zero(self):
+        anchor = self.getAnchor_generic()
         anchor.y = 0
         self.assertEqual(anchor.y, 0)
+    def test_y_set_valid_positive_decimal(self):
+        anchor = self.getAnchor_generic()
         anchor.y = 1.1
         self.assertEqual(anchor.y, 1.1)
+    def test_y_set_valid_negative_decimal(self):
+        anchor = self.getAnchor_generic()
         anchor.y = -1.1
         self.assertEqual(anchor.y, -1.1)
-        # set: invalid
+    def test_y_set_invalid_none(self):
+        anchor = self.getAnchor_generic()
         with self.assertRaises(FontPartsError):
             anchor.y = None
+    def test_y_set_valid_string(self):
+        anchor = self.getAnchor_generic()
         with self.assertRaises(FontPartsError):
             anchor.y = "ABC"
 
@@ -135,109 +177,145 @@ class TestAnchor(unittest.TestCase):
         anchor.color = (0.1, 0.2, 0.3, 0.4)
         return anchor
 
-    def test_copy(self):
+    def test_copy_seperate_objects(self):
         anchor = self.getAnchor_copy()
         copied = anchor.copy()
         self.assertIsNot(anchor, copied)
+    def test_copy_same_name(self):
+        anchor = self.getAnchor_copy()
+        copied = anchor.copy()
         self.assertEqual(anchor.name, copied.name)
+    def test_copy_same_color(self):
+        anchor = self.getAnchor_copy()
+        copied = anchor.copy()
         self.assertEqual(anchor.color, copied.color)
+    def test_copy_same_identifier(self):
+        anchor = self.getAnchor_copy()
+        copied = anchor.copy()
         self.assertEqual(anchor.identifier, copied.identifier)
+    def test_copy_generated_identifier_different(self):
+        anchor = self.getAnchor_copy()
+        copied = anchor.copy()
         anchor.generateIdentifier()
         copied.generateIdentifier()
         self.assertNotEqual(anchor.identifier, copied.identifier)
+    def test_copy_same_x(self):
+        anchor = self.getAnchor_copy()
+        copied = anchor.copy()
         self.assertEqual(anchor.x, copied.x)
+    def test_copy_same_y(self):
+        anchor = self.getAnchor_copy()
+        copied = anchor.copy()
         self.assertEqual(anchor.y, copied.y)
 
-    def test_transformBy(self):
-        # valid + no origin
+    def test_transformBy_valid_no_origin(self):
         anchor = self.getAnchor_generic()
         anchor.transformBy((2, 0, 0, 3, -3, 2))
         self.assertEqual(anchor.x, -1)
         self.assertEqual(anchor.y, 8)
-        # valid + origin
+    def test_transformBy_valid_origin(self):
         anchor = self.getAnchor_generic()
         anchor.transformBy((2, 0, 0, 2, 0, 0), origin=(1, 2))
         self.assertEqual(anchor.x, 1)
         self.assertEqual(anchor.y, 2)
-        # invalid
+    def test_transformBy_invalid_one_string_value(self):
+        anchor = self.getAnchor_generic()
         with self.assertRaises(FontPartsError):
             anchor.transformBy((1, 0, 0, 1, 0, "0"))
+    def test_transformBy_invalid_all_string_values(self):
+        anchor = self.getAnchor_generic()
         with self.assertRaises(FontPartsError):
             anchor.transformBy("1, 0, 0, 1, 0, 0")
+    def test_transformBy_invalid_int_value(self):
+        anchor = self.getAnchor_generic()
         with self.assertRaises(FontPartsError):
             anchor.transformBy(123)
 
-    def test_moveBy(self):
-        # valid + no origin
+    def test_moveBy_valid(self):
         anchor = self.getAnchor_generic()
         anchor.moveBy((-1, 2))
         self.assertEqual(anchor.x, 0)
         self.assertEqual(anchor.y, 4)
-        # invalid
+    def test_moveBy_invalid_one_string_value(self):
+        anchor = self.getAnchor_generic()
         with self.assertRaises(FontPartsError):
-            anchor.transformBy((-1, "2"))
+            anchor.moveBy((-1, "2"))
+    def test_moveBy_invalid_all_strings_value(self):
+        anchor = self.getAnchor_generic()
         with self.assertRaises(FontPartsError):
-            anchor.transformBy("-1, 2")
+            anchor.moveBy("-1, 2")
+    def test_moveBy_invalid_int_value(self):
+        anchor = self.getAnchor_generic()
         with self.assertRaises(FontPartsError):
-            anchor.transformBy(1)
+            anchor.moveBy(1)
 
-    def test_scaleBy(self):
-        # valid + no origin
+    def test_scaleBy_valid_one_value_no_origin(self):
         anchor = self.getAnchor_generic()
         anchor.scaleBy((-2))
         self.assertEqual(anchor.x, -2)
         self.assertEqual(anchor.y, -4)
+    def test_scaleBy_valid_two_values_no_origin(self):
         anchor = self.getAnchor_generic()
         anchor.scaleBy((-2, 3))
         self.assertEqual(anchor.x, -2)
         self.assertEqual(anchor.y, 6)
-        # valid + origin
+    def test_scaleBy_valid_two_values_origin(self):
         anchor = self.getAnchor_generic()
         anchor.scaleBy((-2, 3), origin=(1, 2))
         self.assertEqual(anchor.x, 1)
         self.assertEqual(anchor.y, 2)
-        # invalid
+    def test_scaleBy_invalid_one_string_value(self):
+        anchor = self.getAnchor_generic()
         with self.assertRaises(FontPartsError):
             anchor.scaleBy((-1, "2"))
+    def test_scaleBy_invalid_two_string_values(self):
+        anchor = self.getAnchor_generic()
         with self.assertRaises(FontPartsError):
             anchor.scaleBy("-1, 2")
+    def test_scaleBy_invalid_tuple_too_many_values(self):
+        anchor = self.getAnchor_generic()
         with self.assertRaises(FontPartsError):
             anchor.scaleBy((-1, 2, -3))
 
-    def test_rotateBy(self):
-        # valid + no origin
+    def test_rotateBy_valid_no_origin(self):
         anchor = self.getAnchor_generic()
         anchor.rotateBy(45)
         self.assertAlmostEqual(anchor.x, -0.707, places=3)
         self.assertAlmostEqual(anchor.y, 2.121, places=3)
-        # valid + origin
+    def test_rotateBy_valid_origin(self):
         anchor = self.getAnchor_generic()
         anchor.rotateBy(45, origin=(1, 2))
         self.assertEqual(anchor.x, 1)
         self.assertEqual(anchor.y, 2)
-        # invalid
+    def test_rotateBy_invalid_string_value(self):
+        anchor = self.getAnchor_generic()
         with self.assertRaises(FontPartsError):
             anchor.rotateBy("45")
+    def test_rotateBy_invalid_too_large_value_positive(self):
+        anchor = self.getAnchor_generic()
         with self.assertRaises(FontPartsError):
             anchor.rotateBy(361)
+    def test_rotateBy_invalid_too_large_value_negative(self):
+        anchor = self.getAnchor_generic()
         with self.assertRaises(FontPartsError):
             anchor.rotateBy(-361)
 
-    def test_skewBy(self):
-        # valid + no origin
+    def test_skewBy_valid_no_origin_one_value(self):
         anchor = self.getAnchor_generic()
         anchor.skewBy(100)
         self.assertAlmostEqual(anchor.x, -10.343, places=3)
         self.assertEqual(anchor.y, 2.0)
+    def test_skewBy_valid_no_origin_two_values(self):
         anchor = self.getAnchor_generic()
         anchor.skewBy((100, 200))
         self.assertAlmostEqual(anchor.x, -10.343, places=3)
         self.assertAlmostEqual(anchor.y, 2.364, places=3)
-        # valid + origin
+    def test_skewBy_valid_origin_one_value(self):
         anchor = self.getAnchor_generic()
         anchor.skewBy(100, origin=(1, 2))
         self.assertEqual(anchor.x, 1)
         self.assertEqual(anchor.y, 2)
+    def test_skewBy_valid_origin_two_values(self):
         anchor = self.getAnchor_generic()
         anchor.skewBy((100, 200), origin=(1, 2))
         self.assertEqual(anchor.x, 1)
@@ -249,24 +327,27 @@ class TestAnchor(unittest.TestCase):
         anchor.y = 2.5
         return anchor
 
-    def test_round(self):
+    def test_round_close_to(self):
         anchor = self.getAnchor_round()
         anchor.round()
         self.assertEqual(anchor.x, 1)
+    def test_round_at_half(self):
+        anchor = self.getAnchor_round()
+        anchor.round()
         self.assertEqual(anchor.y, 2)
 
     # ----------
     # Deprecated
     # ----------
 
-    def test_draw(self):
+    def test_removed_draw(self):
         glyph = self.getAnchor_index()
         pen = glyph.getPen()
         anchor = glyph.anchors[0]
         with self.assertRaises(RemovedWarning):
             anchor.draw(pen)
 
-    def test_drawPoints(self):
+    def test_removed_drawPoints(self):
         glyph = self.getAnchor_index()
         pen = glyph.getPen()
         anchor = glyph.anchors[0]
@@ -287,22 +368,32 @@ class TestAnchor(unittest.TestCase):
     # Equality
     # --------
 
-    def test_equal(self):
+    def test_object_equal_self(self):
         anchor_one = self.getAnchor_generic()
         anchor_two = self.getAnchor_generic()
         self.assertEqual(
             anchor_one,
             anchor_one
         )
+    def test_object_notequal_other(self):
+        anchor_one = self.getAnchor_generic()
+        anchor_two = self.getAnchor_generic()
         self.assertNotEqual(
             anchor_one,
             anchor_two
         )
+    def test_object_equal_variable_assignment_self(self):
+        anchor_one = self.getAnchor_generic()
+        anchor_two = self.getAnchor_generic()
         a = anchor_one
         self.assertEqual(
             anchor_one,
             a
         )
+    def test_object_notequal_variable_assignment_other(self):
+        anchor_one = self.getAnchor_generic()
+        anchor_two = self.getAnchor_generic()
+        a = anchor_one
         self.assertNotEqual(
             anchor_two,
             a

--- a/Lib/fontParts/test/test_anchor.py
+++ b/Lib/fontParts/test/test_anchor.py
@@ -8,19 +8,19 @@ from fontTools.misc.py23 import basestring
 class TestAnchor(unittest.TestCase):
 
     def getAnchor_generic(self):
-        anchor, unrequested = self.objectGenerator("anchor")
+        anchor, _unrequested = self.objectGenerator("anchor")
         anchor.name = "Anchor Attribute Test"
         anchor.x = 1
         anchor.y = 2
         anchor.color = None
-        return anchor, unrequested
+        return anchor
 
     # ----------
     # Attributes
     # ----------
 
     def test_name(self):
-        anchor, unrequested = self.getAnchor_generic()
+        anchor = self.getAnchor_generic()
         # get
         self.assertEqual(anchor.name, "Anchor Attribute Test")
         # set: valid
@@ -34,7 +34,7 @@ class TestAnchor(unittest.TestCase):
             anchor.name = 123
 
     def test_color(self):
-        anchor, unrequested = self.getAnchor_generic()
+        anchor = self.getAnchor_generic()
         # get
         self.assertIsNone(anchor.color)
         # set: valid
@@ -60,7 +60,7 @@ class TestAnchor(unittest.TestCase):
             anchor.color = 123
 
     def test_identifier(self):
-        anchor, unrequested = self.getAnchor_generic()
+        anchor = self.getAnchor_generic()
         # get
         self.assertIsNone(anchor.identifier)
         # get
@@ -73,19 +73,19 @@ class TestAnchor(unittest.TestCase):
             anchor.identifier = "ABC"
 
     def getAnchor_index(self):
-        glyph, unrequested = self.objectGenerator("glyph")
+        glyph, _unrequested = self.objectGenerator("glyph")
         glyph.appendAnchor("anchor 0", (0, 0))
         glyph.appendAnchor("anchor 1", (0, 0))
         glyph.appendAnchor("anchor 2", (0, 0))
-        return glyph, unrequested
+        return glyph
 
     def test_index(self):
-        glyph, unrequested = self.getAnchor_index()
+        glyph = self.getAnchor_index()
         for i, anchor in enumerate(glyph.anchors):
             self.assertEqual(anchor.index, i)
 
     def test_x(self):
-        anchor, unrequested = self.getAnchor_generic()
+        anchor = self.getAnchor_generic()
         # get
         self.assertEqual(anchor.x, 1)
         # set: valid
@@ -106,7 +106,7 @@ class TestAnchor(unittest.TestCase):
             anchor.x = "ABC"
 
     def test_y(self):
-        anchor, unrequested = self.getAnchor_generic()
+        anchor = self.getAnchor_generic()
         # get
         self.assertEqual(anchor.y, 2)
         # set: valid
@@ -131,12 +131,12 @@ class TestAnchor(unittest.TestCase):
     # -------
 
     def getAnchor_copy(self):
-        anchor, unrequested = self.getAnchor_generic()
+        anchor, _unrequested = self.getAnchor_generic()
         anchor.color = (0.1, 0.2, 0.3, 0.4)
-        return anchor, unrequested
+        return anchor
 
     def test_copy(self):
-        anchor, unrequested = self.getAnchor_copy()
+        anchor = self.getAnchor_copy()
         copied = anchor.copy()
         self.assertIsNot(anchor, copied)
         self.assertEqual(anchor.name, copied.name)
@@ -150,12 +150,12 @@ class TestAnchor(unittest.TestCase):
 
     def test_transformBy(self):
         # valid + no origin
-        anchor, unrequested = self.getAnchor_generic()
+        anchor = self.getAnchor_generic()
         anchor.transformBy((2, 0, 0, 3, -3, 2))
         self.assertEqual(anchor.x, -1)
         self.assertEqual(anchor.y, 8)
         # valid + origin
-        anchor, unrequested = self.getAnchor_generic()
+        anchor = self.getAnchor_generic()
         anchor.transformBy((2, 0, 0, 2, 0, 0), origin=(1, 2))
         self.assertEqual(anchor.x, 1)
         self.assertEqual(anchor.y, 2)
@@ -169,7 +169,7 @@ class TestAnchor(unittest.TestCase):
 
     def test_moveBy(self):
         # valid + no origin
-        anchor, unrequested = self.getAnchor_generic()
+        anchor = self.getAnchor_generic()
         anchor.moveBy((-1, 2))
         self.assertEqual(anchor.x, 0)
         self.assertEqual(anchor.y, 4)
@@ -183,16 +183,16 @@ class TestAnchor(unittest.TestCase):
 
     def test_scaleBy(self):
         # valid + no origin
-        anchor, unrequested = self.getAnchor_generic()
+        anchor = self.getAnchor_generic()
         anchor.scaleBy((-2))
         self.assertEqual(anchor.x, -2)
         self.assertEqual(anchor.y, -4)
-        anchor, unrequested = self.getAnchor_generic()
+        anchor = self.getAnchor_generic()
         anchor.scaleBy((-2, 3))
         self.assertEqual(anchor.x, -2)
         self.assertEqual(anchor.y, 6)
         # valid + origin
-        anchor, unrequested = self.getAnchor_generic()
+        anchor = self.getAnchor_generic()
         anchor.scaleBy((-2, 3), origin=(1, 2))
         self.assertEqual(anchor.x, 1)
         self.assertEqual(anchor.y, 2)
@@ -206,12 +206,12 @@ class TestAnchor(unittest.TestCase):
 
     def test_rotateBy(self):
         # valid + no origin
-        anchor, unrequested = self.getAnchor_generic()
+        anchor = self.getAnchor_generic()
         anchor.rotateBy(45)
         self.assertAlmostEqual(anchor.x, -0.707, places=3)
         self.assertAlmostEqual(anchor.y, 2.121, places=3)
         # valid + origin
-        anchor, unrequested = self.getAnchor_generic()
+        anchor = self.getAnchor_generic()
         anchor.rotateBy(45, origin=(1, 2))
         self.assertEqual(anchor.x, 1)
         self.assertEqual(anchor.y, 2)
@@ -225,32 +225,32 @@ class TestAnchor(unittest.TestCase):
 
     def test_skewBy(self):
         # valid + no origin
-        anchor, unrequested = self.getAnchor_generic()
+        anchor = self.getAnchor_generic()
         anchor.skewBy(100)
         self.assertAlmostEqual(anchor.x, -10.343, places=3)
         self.assertEqual(anchor.y, 2.0)
-        anchor, unrequested = self.getAnchor_generic()
+        anchor = self.getAnchor_generic()
         anchor.skewBy((100, 200))
         self.assertAlmostEqual(anchor.x, -10.343, places=3)
         self.assertAlmostEqual(anchor.y, 2.364, places=3)
         # valid + origin
-        anchor, unrequested = self.getAnchor_generic()
+        anchor = self.getAnchor_generic()
         anchor.skewBy(100, origin=(1, 2))
         self.assertEqual(anchor.x, 1)
         self.assertEqual(anchor.y, 2)
-        anchor, unrequested = self.getAnchor_generic()
+        anchor = self.getAnchor_generic()
         anchor.skewBy((100, 200), origin=(1, 2))
         self.assertEqual(anchor.x, 1)
         self.assertEqual(anchor.y, 2)
 
     def getAnchor_round(self):
-        anchor, unrequested = self.getAnchor_generic()
+        anchor, _unrequested = self.getAnchor_generic()
         anchor.x = 1.1
         anchor.y = 2.5
-        return anchor, unrequested
+        return anchor
 
     def test_round(self):
-        anchor, unrequested = self.getAnchor_round()
+        anchor = self.getAnchor_round()
         anchor.round()
         self.assertEqual(anchor.x, 1)
         self.assertEqual(anchor.y, 2)
@@ -260,14 +260,14 @@ class TestAnchor(unittest.TestCase):
     # ----------
 
     def test_draw(self):
-        glyph, unrequested = self.getAnchor_index()
+        glyph = self.getAnchor_index()
         pen = glyph.getPen()
         anchor = glyph.anchors[0]
         with self.assertRaises(RemovedWarning):
             anchor.draw(pen)
 
     def test_drawPoints(self):
-        glyph, unrequested = self.getAnchor_index()
+        glyph = self.getAnchor_index()
         pen = glyph.getPen()
         anchor = glyph.anchors[0]
         with self.assertRaises(RemovedWarning):
@@ -277,7 +277,7 @@ class TestAnchor(unittest.TestCase):
     # Hash
     # ----
     def test_hash(self):
-        anchor, unrequested = self.getAnchor_generic()
+        anchor = self.getAnchor_generic()
         self.assertEqual(
             isinstance(anchor, collections.Hashable),
             False
@@ -288,8 +288,8 @@ class TestAnchor(unittest.TestCase):
     # --------
 
     def test_equal(self):
-        anchor_one, unrequested = self.getAnchor_generic()
-        anchor_two, unrequested = self.getAnchor_generic()
+        anchor_one = self.getAnchor_generic()
+        anchor_two = self.getAnchor_generic()
         self.assertEqual(
             anchor_one,
             anchor_one

--- a/Lib/fontParts/test/test_bPoint.py
+++ b/Lib/fontParts/test/test_bPoint.py
@@ -18,17 +18,22 @@ class TestBPoint(unittest.TestCase):
     # Type
     # ----
 
-    def test_type(self):
+    def test_type_corner(self):
         bPoint = self.getBPoint_corner()
         self.assertEqual(
             bPoint.type,
             "corner"
         )
+    def test_type_curve(self):
+        bPoint = self.getBPoint_corner()
         bPoint.type = "curve"
         self.assertEqual(
             bPoint.type,
             "curve"
         )
+    def test_type_not_equal(self):
+        bPoint = self.getBPoint_corner()
+        bPoint.type = "curve"
         self.assertNotEqual(
             bPoint.type,
             "corner"
@@ -38,12 +43,14 @@ class TestBPoint(unittest.TestCase):
     # Anchor
     # ------
 
-    def test_anchor(self):
+    def test_anchor_get(self):
         bPoint = self.getBPoint_corner()
         self.assertEqual(
             bPoint.anchor,
             (101, 202)
         )
+    def test_anchor_change(self):
+        bPoint = self.getBPoint_corner()
         bPoint.anchor = (51,45)
         self.assertEqual(
             bPoint.anchor,
@@ -75,22 +82,31 @@ class TestBPoint(unittest.TestCase):
     # Equality
     # --------
 
-    def test_equal(self):
+    def test_object_equal_self(self):
         bPoint_one = self.getBPoint_corner()
-        bPoint_two = self.getBPoint_corner()
         self.assertEqual(
             bPoint_one,
             bPoint_one
         )
+    def test_object_not_equal_other(self):
+        bPoint_one = self.getBPoint_corner()
+        bPoint_two = self.getBPoint_corner()
         self.assertNotEqual(
             bPoint_one,
             bPoint_two
         )
+    def test_object_equal_self_variable_assignment(self):
+        bPoint_one = self.getBPoint_corner()
         a = bPoint_one
+        a.anchor = (51,45)
         self.assertEqual(
             bPoint_one,
             a
         )
+    def test_object_not_equal_other_variable_assignment(self):
+        bPoint_one = self.getBPoint_corner()
+        bPoint_two = self.getBPoint_corner()
+        a = bPoint_one
         self.assertNotEqual(
             bPoint_two,
             a

--- a/Lib/fontParts/test/test_bPoint.py
+++ b/Lib/fontParts/test/test_bPoint.py
@@ -6,20 +6,20 @@ from fontParts.base import FontPartsError
 class TestBPoint(unittest.TestCase):
 
     def getBPoint_corner(self):
-        contour, unrequested = self.objectGenerator("contour")
-        unrequested.append(contour)
+        contour, _unrequested = self.objectGenerator("contour")
+        _unrequested.append(contour)
         contour.appendPoint((0, 0), "move")
         contour.appendPoint((101, 202), "line")
         contour.appendPoint((303, 0), "line")
         bPoint = contour.bPoints[1]
-        return bPoint, unrequested
+        return bPoint
 
     # ----
     # Type
     # ----
 
     def test_type(self):
-        bPoint, unrequested = self.getBPoint_corner()
+        bPoint = self.getBPoint_corner()
         self.assertEqual(
             bPoint.type,
             "corner"
@@ -39,7 +39,7 @@ class TestBPoint(unittest.TestCase):
     # ------
 
     def test_anchor(self):
-        bPoint, unrequested = self.getBPoint_corner()
+        bPoint = self.getBPoint_corner()
         self.assertEqual(
             bPoint.anchor,
             (101, 202)
@@ -55,7 +55,7 @@ class TestBPoint(unittest.TestCase):
     # -----
 
     def test_index(self):
-        bPoint, unrequested = self.getBPoint_corner()
+        bPoint = self.getBPoint_corner()
         self.assertEqual(
             bPoint.index,
             1
@@ -65,7 +65,7 @@ class TestBPoint(unittest.TestCase):
     # Hash
     # ----
     def test_hash(self):
-        bPoint, unrequested = self.getBPoint_corner()
+        bPoint = self.getBPoint_corner()
         self.assertEqual(
             isinstance(bPoint, collections.Hashable),
             False
@@ -76,8 +76,8 @@ class TestBPoint(unittest.TestCase):
     # --------
 
     def test_equal(self):
-        bPoint_one, unrequested = self.getBPoint_corner()
-        bPoint_two, unrequested = self.getBPoint_corner()
+        bPoint_one = self.getBPoint_corner()
+        bPoint_two = self.getBPoint_corner()
         self.assertEqual(
             bPoint_one,
             bPoint_one

--- a/Lib/fontParts/test/test_component.py
+++ b/Lib/fontParts/test/test_component.py
@@ -15,24 +15,30 @@ class TestComponent(unittest.TestCase):
     # Base Glyph
     # ----------
 
-    def test_baseGlyph(self):
+    def test_baseGlyph_generic(self):
         component = self.getComponent_generic()
         # get
         self.assertEqual(
             component.baseGlyph,
             "A"
         )
-        # set: valid
+    def test_baseGlyph_valid_set(self):
+        component = self.getComponent_generic()
         component.baseGlyph = "B"
         self.assertEqual(
             component.baseGlyph,
             "B"
         )
-        # set: invalid
+    def test_baseGlyph_invalid_set_none(self):
+        component = self.getComponent_generic()
         with self.assertRaises(FontPartsError):
             component.baseGlyph = None
+    def test_baseGlyph_invalid_set_empty_string(self):
+        component = self.getComponent_generic()
         with self.assertRaises(FontPartsError):
             component.baseGlyph = ""
+    def test_baseGlyph_invalid_set_int(self):
+        component = self.getComponent_generic()
         with self.assertRaises(FontPartsError):
             component.baseGlyph = 123
 
@@ -56,24 +62,28 @@ class TestComponent(unittest.TestCase):
         component = glyph.appendComponent("A")
         return component
 
-    def test_bounds(self):
+    def test_bounds_get(self):
         component = self.getComponent_bounds()
-        # get
         self.assertEqual(
             component.bounds,
             (0, 0, 100, 100)
         )
+    def test_bounds_on_move(self):
+        component = self.getComponent_bounds()
         component.moveBy((0.1, -0.1))
         self.assertEqual(
             component.bounds,
             (0.1, -0.1, 100.1, 99.9)
         )
+    def test_bounds_on_scale(self):
+        component = self.getComponent_bounds()
         component.scaleBy((2, 0.5))
         self.assertEqual(
             component.bounds,
-            (0.2, -0.05, 200.2, 49.95)
+            (0, 0, 200, 50)
         )
-        # set
+    def test_bounds_invalid_set(self):
+        component = self.getComponent_bounds()
         with self.assertRaises(FontPartsError):
             component.bounds = (0, 0, 100, 100)
 
@@ -91,22 +101,31 @@ class TestComponent(unittest.TestCase):
     # Equality
     # --------
 
-    def test_equal(self):
+    def test_object_equal_self(self):
         component_one = self.getComponent_generic()
-        component_two = self.getComponent_generic()
         self.assertEqual(
             component_one,
             component_one
         )
+    def test_object_not_equal_other(self):
+        component_one = self.getComponent_generic()
+        component_two = self.getComponent_generic()
         self.assertNotEqual(
             component_one,
             component_two
         )
+    def test_object_equal_assigned_variable(self):
+        component_one = self.getComponent_generic()
         a = component_one
+        a.baseGlyph = "C"
         self.assertEqual(
             component_one,
             a
         )
+    def test_object_not_equal_assigned_variable_other(self):
+        component_one = self.getComponent_generic()
+        component_two = self.getComponent_generic()
+        a = component_one
         self.assertNotEqual(
             component_two,
             a

--- a/Lib/fontParts/test/test_component.py
+++ b/Lib/fontParts/test/test_component.py
@@ -6,17 +6,17 @@ from fontParts.base import FontPartsError
 class TestComponent(unittest.TestCase):
 
     def getComponent_generic(self):
-        component, unrequested = self.objectGenerator("component")
+        component, _unrequested = self.objectGenerator("component")
         component.baseGlyph = "A"
         component.transformation = (1, 0, 0, 1, 0, 0)
-        return component, unrequested
+        return component
 
     # ----------
     # Base Glyph
     # ----------
 
     def test_baseGlyph(self):
-        component, unrequested = self.getComponent_generic()
+        component = self.getComponent_generic()
         # get
         self.assertEqual(
             component.baseGlyph,
@@ -41,10 +41,10 @@ class TestComponent(unittest.TestCase):
     # ------
 
     def getComponent_bounds(self):
-        font, unrequested = self.objectGenerator("font")
-        unrequested.append(font)
+        font = self.objectGenerator("font")
+        _unrequested.append(font)
         glyph = font.newGlyph("A")
-        unrequested.append(glyph)
+        _unrequested.append(glyph)
         pen = glyph.getPen()
         pen.moveTo((0, 0))
         pen.lineTo((0, 100))
@@ -52,12 +52,12 @@ class TestComponent(unittest.TestCase):
         pen.lineTo((100, 0))
         pen.closePath()
         glyph = font.newGlyph("B")
-        unrequested.append(glyph)
+        _unrequested.append(glyph)
         component = glyph.appendComponent("A")
-        return component, unrequested
+        return component
 
     def test_bounds(self):
-        component, unrequested = self.getComponent_bounds()
+        component = self.getComponent_bounds()
         # get
         self.assertEqual(
             component.bounds,
@@ -81,7 +81,7 @@ class TestComponent(unittest.TestCase):
     # Hash
     # ----
     def test_hash(self):
-        component, unrequested = self.getComponent_generic()
+        component = self.getComponent_generic()
         self.assertEqual(
             isinstance(component, collections.Hashable),
             False
@@ -92,8 +92,8 @@ class TestComponent(unittest.TestCase):
     # --------
 
     def test_equal(self):
-        component_one, unrequested = self.getComponent_generic()
-        component_two, unrequested = self.getComponent_generic()
+        component_one = self.getComponent_generic()
+        component_two = self.getComponent_generic()
         self.assertEqual(
             component_one,
             component_one

--- a/Lib/fontParts/test/test_component.py
+++ b/Lib/fontParts/test/test_component.py
@@ -41,7 +41,7 @@ class TestComponent(unittest.TestCase):
     # ------
 
     def getComponent_bounds(self):
-        font = self.objectGenerator("font")
+        font, _unrequested = self.objectGenerator("font")
         _unrequested.append(font)
         glyph = font.newGlyph("A")
         _unrequested.append(glyph)

--- a/Lib/fontParts/test/test_contour.py
+++ b/Lib/fontParts/test/test_contour.py
@@ -27,27 +27,29 @@ class TestContour(unittest.TestCase):
         contour.appendPoint((50, 0), "curve")
         return contour
 
-    def test_bounds(self):
-        # get
+    def test_bounds_get(self):
         contour = self.getContour_bounds()
         self.assertEqual(
             contour.bounds,
             (0, 0, 100, 100)
         )
-        # get: float
+    def test_bounds_set_float(self):
+        contour = self.getContour_bounds()
         contour.moveBy((0.5, -0.5))
         self.assertEqual(
             contour.bounds,
             (0.5, -0.5, 100.5, 99.5)
         )
-        # get: point not at extrema
+    def test_bounds_point_not_at_extrema(self):
+        contour = self.getContour_bounds()
         contour = self.getContour_boundsExtrema()
         bounds = tuple(int(round(i)) for i in contour.bounds)
         self.assertEqual(
             bounds,
             (0, 0, 100, 100)
         )
-        # set
+    def test_invalid_bounds_set(self):
+        contour = self.getContour_bounds()
         with self.assertRaises(FontPartsError):
             contour.bounds = (1, 2, 3, 4)
 
@@ -65,22 +67,31 @@ class TestContour(unittest.TestCase):
     # Equality
     # --------
 
-    def test_equal(self):
+    def test_object_equal_self(self):
         contour_one = self.getContour_bounds()
-        contour_two = self.getContour_bounds()
         self.assertEqual(
             contour_one,
             contour_one
         )
+    def test_object_not_equal_self(self):
+        contour_one = self.getContour_bounds()
+        contour_two = self.getContour_bounds()
         self.assertNotEqual(
             contour_one,
             contour_two
         )
+    def test_object_equal_self_variable_assignment(self):
+        contour_one = self.getContour_bounds()
         a = contour_one
+        a.moveBy((0.5, -0.5))
         self.assertEqual(
             contour_one,
             a
         )
+    def test_object_not_equal_self_variable_assignment(self):
+        contour_one = self.getContour_bounds()
+        contour_two = self.getContour_bounds()
+        a = contour_one
         self.assertNotEqual(
             contour_two,
             a

--- a/Lib/fontParts/test/test_contour.py
+++ b/Lib/fontParts/test/test_contour.py
@@ -10,26 +10,26 @@ class TestContour(unittest.TestCase):
     # ------
 
     def getContour_bounds(self):
-        contour, unrequested = self.objectGenerator("contour")
+        contour, _unrequested = self.objectGenerator("contour")
         contour.appendPoint((0, 0), "line")
         contour.appendPoint((0, 100), "line")
         contour.appendPoint((100, 100), "line")
         contour.appendPoint((100, 0), "line")
-        return contour, unrequested
+        return contour
 
     def getContour_boundsExtrema(self):
-        contour, unrequested = self.objectGenerator("contour")
+        contour, _unrequested = self.objectGenerator("contour")
         contour.appendPoint((0, 0), "line")
         contour.appendPoint((0, 100), "line")
         contour.appendPoint((50, 100), "line")
         contour.appendPoint((117, 100), "offcurve")
         contour.appendPoint((117, 0), "offcurve")
         contour.appendPoint((50, 0), "curve")
-        return contour, unrequested
+        return contour
 
     def test_bounds(self):
         # get
-        contour, unrequested = self.getContour_bounds()
+        contour = self.getContour_bounds()
         self.assertEqual(
             contour.bounds,
             (0, 0, 100, 100)
@@ -41,7 +41,7 @@ class TestContour(unittest.TestCase):
             (0.5, -0.5, 100.5, 99.5)
         )
         # get: point not at extrema
-        contour, unrequested = self.getContour_boundsExtrema()
+        contour = self.getContour_boundsExtrema()
         bounds = tuple(int(round(i)) for i in contour.bounds)
         self.assertEqual(
             bounds,
@@ -55,7 +55,7 @@ class TestContour(unittest.TestCase):
     # Hash
     # ----
     def test_hash(self):
-        contour, unrequested = self.getContour_bounds()
+        contour = self.getContour_bounds()
         self.assertEqual(
             isinstance(contour, collections.Hashable),
             False
@@ -66,8 +66,8 @@ class TestContour(unittest.TestCase):
     # --------
 
     def test_equal(self):
-        contour_one, unrequested = self.getContour_bounds()
-        contour_two, unrequested = self.getContour_bounds()
+        contour_one = self.getContour_bounds()
+        contour_two = self.getContour_bounds()
         self.assertEqual(
             contour_one,
             contour_one

--- a/Lib/fontParts/test/test_features.py
+++ b/Lib/fontParts/test/test_features.py
@@ -14,22 +14,25 @@ class TestFeatures(unittest.TestCase):
     # Text
     # ----
 
-    def test_text(self):
+    def test_text_get(self):
         features = self.getFeatures_generic()
-        # get
         self.assertEqual(
             features.text,
             "# test"
         )
-        # set: valid
+    def test_text_valid_set(self):
+        features = self.getFeatures_generic()
         features.text = "# foo"
         self.assertEqual(
             features.text,
             "# foo"
         )
+    def test_text_set_none(self):
+        features = self.getFeatures_generic()
         features.text = None
         self.assertIsNone(features.text)
-        # set: invalid
+    def test_text_invalid_set(self):
+        features = self.getFeatures_generic()
         with self.assertRaises(FontPartsError):
             features.text = 123
 
@@ -47,22 +50,31 @@ class TestFeatures(unittest.TestCase):
     # Equality
     # --------
 
-    def test_equal(self):
+    def test_object_equal_self(self):
         features_one = self.getFeatures_generic()
-        features_two = self.getFeatures_generic()
         self.assertEqual(
             features_one,
             features_one
         )
+    def test_object_not_equal_other(self):
+        features_one = self.getFeatures_generic()
+        features_two = self.getFeatures_generic()
         self.assertNotEqual(
             features_one,
             features_two
         )
+    def test_object_equal_self_variable_assignment(self):
+        features_one = self.getFeatures_generic()
         a = features_one
+        a.text += "# testing"
         self.assertEqual(
             features_one,
             a
         )
+    def test_object_not_equal_self_variable_assignment(self):
+        features_one = self.getFeatures_generic()
+        features_two = self.getFeatures_generic()
+        a = features_one
         self.assertNotEqual(
             features_two,
             a

--- a/Lib/fontParts/test/test_features.py
+++ b/Lib/fontParts/test/test_features.py
@@ -6,16 +6,16 @@ from fontParts.base import FontPartsError
 class TestFeatures(unittest.TestCase):
 
     def getFeatures_generic(self):
-        features, unreferenced = self.objectGenerator("features")
+        features, _unrequested = self.objectGenerator("features")
         features.text = "# test"
-        return features, unreferenced
+        return features
 
     # ----
     # Text
     # ----
 
     def test_text(self):
-        features, unreferenced = self.getFeatures_generic()
+        features = self.getFeatures_generic()
         # get
         self.assertEqual(
             features.text,
@@ -37,7 +37,7 @@ class TestFeatures(unittest.TestCase):
     # Hash
     # ----
     def test_hash(self):
-        features, unrequested = self.getFeatures_generic()
+        features = self.getFeatures_generic()
         self.assertEqual(
             isinstance(features, collections.Hashable),
             False
@@ -48,8 +48,8 @@ class TestFeatures(unittest.TestCase):
     # --------
 
     def test_equal(self):
-        features_one, unrequested = self.getFeatures_generic()
-        features_two, unrequested = self.getFeatures_generic()
+        features_one = self.getFeatures_generic()
+        features_two = self.getFeatures_generic()
         self.assertEqual(
             features_one,
             features_one

--- a/Lib/fontParts/test/test_font.py
+++ b/Lib/fontParts/test/test_font.py
@@ -17,14 +17,14 @@ class TestFont(unittest.TestCase):
 
     # len
 
-    def test_len(self):
+    def test_len_initial(self):
         font = self.getFont_glyphs()
-        # one layer
         self.assertEqual(
             len(font),
             4
         )
-        # two layers
+    def test_len_two_layers(self):
+        font = self.getFont_glyphs()
         layer = font.newLayer("test")
         layer.newGlyph("X")
         self.assertEqual(
@@ -36,26 +36,36 @@ class TestFont(unittest.TestCase):
     # Hash
     # ----
 
-    def test_hash(self):
+    def test_hash_same_object(self):
         font_one = self.getFont_glyphs()
-        font_two = self.getFont_glyphs()
         self.assertEqual(
             hash(font_one),
             hash(font_one)
         )
+    def test_hash_different_object(self):
+        font_one = self.getFont_glyphs()
+        font_two = self.getFont_glyphs()
         self.assertNotEqual(
             hash(font_one),
             hash(font_two)
         )
+    def test_hash_same_object_variable_assignment(self):
+        font_one = self.getFont_glyphs()
         a = font_one
         self.assertEqual(
             hash(font_one),
             hash(a)
         )
+    def test_hash_different_object_variable_assignment(self):
+        font_one = self.getFont_glyphs()
+        font_two = self.getFont_glyphs()
+        a = font_one
         self.assertNotEqual(
             hash(font_two),
             hash(a)
         )
+    def test_hash_is_hasbable(self):
+        font_one = self.getFont_glyphs()
         self.assertEqual(
             isinstance(font_one, collections.Hashable),
             True
@@ -65,22 +75,31 @@ class TestFont(unittest.TestCase):
     # Equality
     # --------
 
-    def test_equal(self):
+    def test_object_equal_self(self):
         font_one = self.getFont_glyphs()
-        font_two = self.getFont_glyphs()
         self.assertEqual(
             font_one,
             font_one
         )
+    def test_object_not_equal_other(self):
+        font_one = self.getFont_glyphs()
+        font_two = self.getFont_glyphs()
         self.assertNotEqual(
             font_one,
             font_two
         )
+    def test_object_equal_self_variable_assignment(self):
+        font_one = self.getFont_glyphs()
         a = font_one
+        glyph = a.newGlyph("XYZ")
         self.assertEqual(
             font_one,
             a
         )
+    def test_object_not_equal_other_variable_assignment(self):
+        font_one = self.getFont_glyphs()
+        font_two = self.getFont_glyphs()
+        a = font_one
         self.assertNotEqual(
             font_two,
             a

--- a/Lib/fontParts/test/test_font.py
+++ b/Lib/fontParts/test/test_font.py
@@ -10,15 +10,15 @@ class TestFont(unittest.TestCase):
     # ------
 
     def getFont_glyphs(self):
-        font, unrequested = self.objectGenerator("font")
+        font, _unrequested = self.objectGenerator("font")
         for name in "ABCD":
             glyph = font.newGlyph(name)
-        return font, unrequested
+        return font
 
     # len
 
     def test_len(self):
-        font, unrequested = self.getFont_glyphs()
+        font = self.getFont_glyphs()
         # one layer
         self.assertEqual(
             len(font),
@@ -37,8 +37,8 @@ class TestFont(unittest.TestCase):
     # ----
 
     def test_hash(self):
-        font_one, unrequested = self.getFont_glyphs()
-        font_two, unrequested = self.getFont_glyphs()
+        font_one = self.getFont_glyphs()
+        font_two = self.getFont_glyphs()
         self.assertEqual(
             hash(font_one),
             hash(font_one)
@@ -66,8 +66,8 @@ class TestFont(unittest.TestCase):
     # --------
 
     def test_equal(self):
-        font_one, unrequested = self.getFont_glyphs()
-        font_two, unrequested = self.getFont_glyphs()
+        font_one = self.getFont_glyphs()
+        font_two = self.getFont_glyphs()
         self.assertEqual(
             font_one,
             font_one

--- a/Lib/fontParts/test/test_font.py
+++ b/Lib/fontParts/test/test_font.py
@@ -91,7 +91,7 @@ class TestFont(unittest.TestCase):
     def test_object_equal_self_variable_assignment(self):
         font_one = self.getFont_glyphs()
         a = font_one
-        glyph = a.newGlyph("XYZ")
+        a.newGlyph("XYZ")
         self.assertEqual(
             font_one,
             a

--- a/Lib/fontParts/test/test_glyph.py
+++ b/Lib/fontParts/test/test_glyph.py
@@ -22,32 +22,46 @@ class TestGlyph(unittest.TestCase):
     # Metrics
     # -------
 
-    def test_width(self):
-        # get
+    def test_width_get(self):
         glyph = self.getGlyph_generic()
         self.assertEqual(
             glyph.width,
             250
         )
-        # set: valid
+    def test_width_set_valid_positive(self):
+        glyph = self.getGlyph_generic()
         glyph.width = 300
         self.assertEqual(
             glyph.width,
             300
         )
+    def test_width_set_valid_zero(self):
+        glyph = self.getGlyph_generic()
         glyph.width = 0
         self.assertEqual(
             glyph.width,
             0
         )
+    def test_width_set_valid_float(self):
+        glyph = self.getGlyph_generic()
         glyph.width = 101.5
         self.assertEqual(
             glyph.width,
             101.5
         )
-        # set: invalid
+    def test_width_set_valid_negative(self):
+        glyph = self.getGlyph_generic()
+        glyph.width = -485
+        self.assertEqual(
+            glyph.width,
+            -485
+        )
+    def test_width_set_invalid_string(self):
+        glyph = self.getGlyph_generic()
         with self.assertRaises(FontPartsError):
             glyph.width = "abc"
+    def test_width_set_invalid_none(self):
+        glyph = self.getGlyph_generic()
         with self.assertRaises(FontPartsError):
             glyph.width = None
 
@@ -55,28 +69,39 @@ class TestGlyph(unittest.TestCase):
     # Hash
     # ----
 
-    def test_hash(self):
+    def test_hash_object_self(self):
         glyph_one = self.getGlyph_generic()
-        glyph_two = self.getGlyph_generic()
         glyph_one.name = "Test"
         self.assertEqual(
             hash(glyph_one),
             hash(glyph_one)
         )
+    def test_hash_object_other(self):
+        glyph_one = self.getGlyph_generic()
+        glyph_two = self.getGlyph_generic()
+        glyph_one.name = "Test"
         glyph_two.name = "Test"
         self.assertNotEqual(
             hash(glyph_one),
             hash(glyph_two)
         )
+    def test_hash_object_self_variable_assignment(self):
+        glyph_one = self.getGlyph_generic()
         a = glyph_one
         self.assertEqual(
             hash(glyph_one),
             hash(a)
         )
+    def test_hash_object_other_variable_assignment(self):
+        glyph_one = self.getGlyph_generic()
+        glyph_two = self.getGlyph_generic()
+        a = glyph_one
         self.assertNotEqual(
             hash(glyph_two),
             hash(a)
         )
+    def test_is_hashable(self):
+        glyph_one = self.getGlyph_generic()
         self.assertEqual(
             isinstance(glyph_one, collections.Hashable),
             True
@@ -86,28 +111,41 @@ class TestGlyph(unittest.TestCase):
     # Equality
     # --------
 
-    def test_equal(self):
+    def test_object_equal_self(self):
         glyph_one = self.getGlyph_generic()
-        glyph_two = self.getGlyph_generic()
         glyph_one.name = "Test"
         self.assertEqual(
             glyph_one,
             glyph_one
         )
+    def test_object_not_equal_other(self):
+        glyph_one = self.getGlyph_generic()
+        glyph_two = self.getGlyph_generic()
         self.assertNotEqual(
             glyph_one,
             glyph_two
         )
+    def test_object_not_equal_other_name_same(self):
+        glyph_one = self.getGlyph_generic()
+        glyph_two = self.getGlyph_generic()
+        glyph_one.name = "Test"
         glyph_two.name = "Test"
         self.assertNotEqual(
             glyph_one,
             glyph_two
         )
+    def test_object_equal_variable_assignment(self):
+        glyph_one = self.getGlyph_generic()
         a = glyph_one
+        a.name = "Other"
         self.assertEqual(
             glyph_one,
             a
         )
+    def test_object_not_equal_variable_assignment(self):
+        glyph_one = self.getGlyph_generic()
+        glyph_two = self.getGlyph_generic()
+        a = glyph_one
         self.assertNotEqual(
             glyph_two,
             a

--- a/Lib/fontParts/test/test_glyph.py
+++ b/Lib/fontParts/test/test_glyph.py
@@ -6,7 +6,7 @@ from fontParts.base import FontPartsError
 class TestGlyph(unittest.TestCase):
 
     def getGlyph_generic(self):
-        glyph, unrequested = self.objectGenerator("glyph")
+        glyph, _unrequested = self.objectGenerator("glyph")
         glyph.name = "Test Glyph 1"
         glyph.unicode = int(ord("X"))
         glyph.width = 250
@@ -16,7 +16,7 @@ class TestGlyph(unittest.TestCase):
         pen.lineTo((200, 100))
         pen.lineTo((200, 0))
         pen.closePath()
-        return glyph, unrequested
+        return glyph
 
     # -------
     # Metrics
@@ -24,7 +24,7 @@ class TestGlyph(unittest.TestCase):
 
     def test_width(self):
         # get
-        glyph, unrequested = self.getGlyph_generic()
+        glyph = self.getGlyph_generic()
         self.assertEqual(
             glyph.width,
             250
@@ -56,8 +56,8 @@ class TestGlyph(unittest.TestCase):
     # ----
 
     def test_hash(self):
-        glyph_one, unrequested = self.getGlyph_generic()
-        glyph_two, unrequested = self.getGlyph_generic()
+        glyph_one = self.getGlyph_generic()
+        glyph_two = self.getGlyph_generic()
         glyph_one.name = "Test"
         self.assertEqual(
             hash(glyph_one),
@@ -87,8 +87,8 @@ class TestGlyph(unittest.TestCase):
     # --------
 
     def test_equal(self):
-        glyph_one, unrequested = self.getGlyph_generic()
-        glyph_two, unrequested = self.getGlyph_generic()
+        glyph_one = self.getGlyph_generic()
+        glyph_two = self.getGlyph_generic()
         glyph_one.name = "Test"
         self.assertEqual(
             glyph_one,

--- a/Lib/fontParts/test/test_groups.py
+++ b/Lib/fontParts/test/test_groups.py
@@ -6,21 +6,21 @@ from fontParts.base import FontPartsError
 class TestGroups(unittest.TestCase):
 
     def getGroups_generic(self):
-        groups, unrequested = self.objectGenerator("groups")
+        groups, _unrequested = self.objectGenerator("groups")
         groups.update({
             "group 1" : ["A", "B", "C"],
             "group 2" : ["x", "y", "z"],
             "group 3" : [],
             "group 4" : ["A"]
         })
-        return groups, unrequested
+        return groups
 
     # ---
     # len
     # ---
 
     def test_len(self):
-        groups, unrequested = self.getGroups_generic()
+        groups = self.getGroups_generic()
         self.assertEqual(
             len(groups),
             4
@@ -36,7 +36,7 @@ class TestGroups(unittest.TestCase):
     # ---------
 
     def test_find(self):
-        groups, unrequested = self.getGroups_generic()
+        groups = self.getGroups_generic()
         found = groups.findGlyph("A")
         found.sort()
         self.assertEqual(
@@ -55,7 +55,7 @@ class TestGroups(unittest.TestCase):
     # Hash
     # ----
     def test_hash(self):
-        groups, unrequested = self.getGroups_generic()
+        groups = self.getGroups_generic()
         self.assertEqual(
             isinstance(groups, collections.Hashable),
             False
@@ -66,8 +66,8 @@ class TestGroups(unittest.TestCase):
     # --------
 
     def test_equal(self):
-        groups_one, unrequested = self.getGroups_generic()
-        groups_two, unrequested = self.getGroups_generic()
+        groups_one = self.getGroups_generic()
+        groups_two = self.getGroups_generic()
         self.assertEqual(
             groups_one,
             groups_one

--- a/Lib/fontParts/test/test_groups.py
+++ b/Lib/fontParts/test/test_groups.py
@@ -19,12 +19,14 @@ class TestGroups(unittest.TestCase):
     # len
     # ---
 
-    def test_len(self):
+    def test_len_initial(self):
         groups = self.getGroups_generic()
         self.assertEqual(
             len(groups),
             4
         )
+    def test_len_clear(self):
+        groups = self.getGroups_generic()
         groups.clear()
         self.assertEqual(
             len(groups),
@@ -35,7 +37,7 @@ class TestGroups(unittest.TestCase):
     # Searching
     # ---------
 
-    def test_find(self):
+    def test_find_found(self):
         groups = self.getGroups_generic()
         found = groups.findGlyph("A")
         found.sort()
@@ -43,11 +45,14 @@ class TestGroups(unittest.TestCase):
             found,
             [u"group 1", u"group 4"]
         )
+    def test_find_not_found(self):
+        groups = self.getGroups_generic()
         self.assertEqual(
             groups.findGlyph("five"),
             []
         )
-        # find: invalid
+    def test_find_invalid_key(self):
+        groups = self.getGroups_generic()
         with self.assertRaises(FontPartsError):
             groups.findGlyph(5)
 
@@ -65,22 +70,30 @@ class TestGroups(unittest.TestCase):
     # Equality
     # --------
 
-    def test_equal(self):
+    def test_object_equal_self(self):
         groups_one = self.getGroups_generic()
-        groups_two = self.getGroups_generic()
         self.assertEqual(
             groups_one,
             groups_one
         )
+    def test_object_not_equal_other(self):
+        groups_one = self.getGroups_generic()
+        groups_two = self.getGroups_generic()
         self.assertNotEqual(
             groups_one,
             groups_two
         )
+    def test_object_equal_self_variable_assignment(self):
+        groups_one = self.getGroups_generic()
         a = groups_one
         self.assertEqual(
             groups_one,
             a
         )
+    def test_object_not_equal_other_variable_assignment(self):
+        groups_one = self.getGroups_generic()
+        groups_two = self.getGroups_generic()
+        a = groups_one
         self.assertNotEqual(
             groups_two,
             a

--- a/Lib/fontParts/test/test_guideline.py
+++ b/Lib/fontParts/test/test_guideline.py
@@ -6,18 +6,18 @@ from fontParts.base import FontPartsError
 class TestGuideline(unittest.TestCase):
 
     def getGuideline_generic(self):
-        guideline, unrequested = self.objectGenerator("guideline")
+        guideline, _unrequested = self.objectGenerator("guideline")
         guideline.x = 1
         guideline.y = 2
         guideline.angle = 90
-        return guideline, unrequested
+        return guideline
 
     # --------
     # Position
     # --------
 
     def test_x(self):
-        guideline, unrequested = self.getGuideline_generic()
+        guideline = self.getGuideline_generic()
         # get
         self.assertEqual(
             guideline.x,
@@ -57,7 +57,7 @@ class TestGuideline(unittest.TestCase):
     # Hash
     # ----
     def test_hash(self):
-        guideline, unrequested = self.getGuideline_generic()
+        guideline = self.getGuideline_generic()
         self.assertEqual(
             isinstance(guideline, collections.Hashable),
             False
@@ -68,8 +68,8 @@ class TestGuideline(unittest.TestCase):
     # --------
 
     def test_equal(self):
-        guideline_one, unrequested = self.getGuideline_generic()
-        guideline_two, unrequested = self.getGuideline_generic()
+        guideline_one = self.getGuideline_generic()
+        guideline_two = self.getGuideline_generic()
         self.assertEqual(
             guideline_one,
             guideline_one

--- a/Lib/fontParts/test/test_guideline.py
+++ b/Lib/fontParts/test/test_guideline.py
@@ -16,42 +16,97 @@ class TestGuideline(unittest.TestCase):
     # Position
     # --------
 
-    def test_x(self):
+    def test_x_get(self):
         guideline = self.getGuideline_generic()
-        # get
         self.assertEqual(
             guideline.x,
             1
         )
-        # set: valid
+    def test_x_set_valid_zero(self):
+        guideline = self.getGuideline_generic()
         guideline.x = 0
         self.assertEqual(
             guideline.x,
             0
         )
+    def test_x_set_valid_positive(self):
+        guideline = self.getGuideline_generic()
         guideline.x = 1
         self.assertEqual(
             guideline.x,
             1
         )
+    def test_x_set_valid_negative(self):
+        guideline = self.getGuideline_generic()
         guideline.x = -1
         self.assertEqual(
             guideline.x,
             -1
         )
+    def test_x_set_valid_positive_float(self):
+        guideline = self.getGuideline_generic()
         guideline.x = 1.1
         self.assertEqual(
             guideline.x,
             1.1
         )
+    def test_x_set_valid_negative_float(self):
+        guideline = self.getGuideline_generic()
         guideline.x = -1.1
         self.assertEqual(
             guideline.x,
             -1.1
         )
-        # set: invalid
+    def test_x_set_invalid_string(self):
+        guideline = self.getGuideline_generic()
         with self.assertRaises(FontPartsError):
             guideline.x = "ABC"
+
+    def test_y_get(self):
+        guideline = self.getGuideline_generic()
+        self.assertEqual(
+            guideline.y,
+            2
+        )
+    def test_y_set_valid_zero(self):
+        guideline = self.getGuideline_generic()
+        guideline.y = 0
+        self.assertEqual(
+            guideline.y,
+            0
+        )
+    def test_y_set_valid_positive(self):
+        guideline = self.getGuideline_generic()
+        guideline.y = 1
+        self.assertEqual(
+            guideline.y,
+            1
+        )
+    def test_y_set_valid_negative(self):
+        guideline = self.getGuideline_generic()
+        guideline.y = -1
+        self.assertEqual(
+            guideline.y,
+            -1
+        )
+    def test_y_set_valid_positive_float(self):
+        guideline = self.getGuideline_generic()
+        guideline.y = 1.1
+        self.assertEqual(
+            guideline.y,
+            1.1
+        )
+    def test_y_set_valid_negative_float(self):
+        guideline = self.getGuideline_generic()
+        guideline.y = -1.1
+        self.assertEqual(
+            guideline.y,
+            -1.1
+        )
+    def test_y_set_invalid_string(self):
+        guideline = self.getGuideline_generic()
+        with self.assertRaises(FontPartsError):
+            guideline.y = "ABC"
 
     # ----
     # Hash
@@ -67,22 +122,31 @@ class TestGuideline(unittest.TestCase):
     # Equality
     # --------
 
-    def test_equal(self):
+    def test_object_equal_self(self):
         guideline_one = self.getGuideline_generic()
-        guideline_two = self.getGuideline_generic()
         self.assertEqual(
             guideline_one,
             guideline_one
         )
+    def test_object_not_equal_other(self):
+        guideline_one = self.getGuideline_generic()
+        guideline_two = self.getGuideline_generic()
         self.assertNotEqual(
             guideline_one,
             guideline_two
         )
+    def test_object_equal_self_variable_assignment(self):
+        guideline_one = self.getGuideline_generic()
         a = guideline_one
+        a.x = 200
         self.assertEqual(
             guideline_one,
             a
         )
+    def test_object_not_equal_other_variable_assignment(self):
+        guideline_one = self.getGuideline_generic()
+        guideline_two = self.getGuideline_generic()
+        a = guideline_one
         self.assertNotEqual(
             guideline_two,
             a

--- a/Lib/fontParts/test/test_image.py
+++ b/Lib/fontParts/test/test_image.py
@@ -269,20 +269,22 @@ class TestImage(unittest.TestCase):
     # Data
     # ----
 
-    def test_data(self):
+    def test_data_get(self):
         image = self.getImage_generic()
         # get
         self.assertEqual(
             image.data,
             testImageData
         )
-        # set: valid
+    def test_data_set_valid(self):
+        image = self.getImage_generic()
         image.data = testImageData
         self.assertEqual(
             image.data,
             testImageData
         )
-        # set: invalid
+    def test_data_set_invalid(self):
+        image = self.getImage_generic()
         with self.assertRaises(FontPartsError):
             image.data = 123
 
@@ -300,22 +302,30 @@ class TestImage(unittest.TestCase):
     # Equality
     # --------
 
-    def test_equal(self):
+    def test_object_equal_self(self):
         image_one = self.getImage_generic()
-        image_two = self.getImage_generic()
         self.assertEqual(
             image_one,
             image_one
         )
+    def test_object_not_equal_other(self):
+        image_one = self.getImage_generic()
+        image_two = self.getImage_generic()
         self.assertNotEqual(
             image_one,
             image_two
         )
+    def test_object_equal_self_variable_assignment(self):
+        image_one = self.getImage_generic()
         a = image_one
         self.assertEqual(
             image_one,
             a
         )
+    def test_object_not_equal_other_variable_assignment(self):
+        image_one = self.getImage_generic()
+        image_two = self.getImage_generic()
+        a = image_one
         self.assertNotEqual(
             image_two,
             a

--- a/Lib/fontParts/test/test_image.py
+++ b/Lib/fontParts/test/test_image.py
@@ -260,17 +260,17 @@ testImageData = testImageData.encode('utf-8')
 class TestImage(unittest.TestCase):
 
     def getImage_generic(self):
-        image, unrequested = self.objectGenerator("image")
+        image, _unrequested = self.objectGenerator("image")
         image.data = testImageData
         image.transformation = (1, 0, 0, 1, 0, 0)
-        return image, unrequested
+        return image
 
     # ----
     # Data
     # ----
 
     def test_data(self):
-        image, unrequested = self.getImage_generic()
+        image = self.getImage_generic()
         # get
         self.assertEqual(
             image.data,
@@ -290,7 +290,7 @@ class TestImage(unittest.TestCase):
     # Hash
     # ----
     def test_hash(self):
-        image, unrequested = self.getImage_generic()
+        image = self.getImage_generic()
         self.assertEqual(
             isinstance(image, collections.Hashable),
             False
@@ -301,8 +301,8 @@ class TestImage(unittest.TestCase):
     # --------
 
     def test_equal(self):
-        image_one, unrequested = self.getImage_generic()
-        image_two, unrequested = self.getImage_generic()
+        image_one = self.getImage_generic()
+        image_two = self.getImage_generic()
         self.assertEqual(
             image_one,
             image_one

--- a/Lib/fontParts/test/test_info.py
+++ b/Lib/fontParts/test/test_info.py
@@ -6,16 +6,16 @@ from fontParts.base import FontPartsError
 class TestInfo(unittest.TestCase):
 
     def getInfo_generic(self):
-        info, unrequested = self.objectGenerator("info")
+        info, _unrequested = self.objectGenerator("info")
         info.unitsPerEm = 1000
-        return info, unrequested
+        return info
 
     # ----------
     # Dimensions
     # ----------
 
     def test_unitsPerEm(self):
-        info, unrequested = self.getInfo_generic()
+        info = self.getInfo_generic()
         # get
         self.assertEqual(
             info.unitsPerEm,
@@ -42,7 +42,7 @@ class TestInfo(unittest.TestCase):
     # Hash
     # ----
     def test_hash(self):
-        info, unrequested = self.getInfo_generic()
+        info = self.getInfo_generic()
         self.assertEqual(
             isinstance(info, collections.Hashable),
             False
@@ -53,8 +53,8 @@ class TestInfo(unittest.TestCase):
     # --------
 
     def test_equal(self):
-        info_one, unrequested = self.getInfo_generic()
-        info_two, unrequested = self.getInfo_generic()
+        info_one = self.getInfo_generic()
+        info_two = self.getInfo_generic()
         self.assertEqual(
             info_one,
             info_one

--- a/Lib/fontParts/test/test_info.py
+++ b/Lib/fontParts/test/test_info.py
@@ -14,27 +14,32 @@ class TestInfo(unittest.TestCase):
     # Dimensions
     # ----------
 
-    def test_unitsPerEm(self):
+    def test_get_unitsPerEm(self):
         info = self.getInfo_generic()
-        # get
         self.assertEqual(
             info.unitsPerEm,
             1000
         )
-        # set: valid
+    def test_set_valid_unitsPerEm_int(self):
+        info = self.getInfo_generic()
         info.unitsPerEm = 2000
         self.assertEqual(
             info.unitsPerEm,
             2000
         )
+    def test_set_valid_unitsPerEm_float(self):
+        info = self.getInfo_generic()
         info.unitsPerEm = 2000.1
         self.assertEqual(
             info.unitsPerEm,
             2000.1
         )
-        # set: invalid
+    def test_set_invalid_unitsPerEm_negative(self):
+        info = self.getInfo_generic()
         with self.assertRaises(FontPartsError):
             info.unitsPerEm = -1000
+    def test_set_invalid_unitsPerEm_string(self):
+        info = self.getInfo_generic()
         with self.assertRaises(FontPartsError):
             info.unitsPerEm = "abc"
 
@@ -52,22 +57,30 @@ class TestInfo(unittest.TestCase):
     # Equality
     # --------
 
-    def test_equal(self):
+    def test_object_equal_self(self):
         info_one = self.getInfo_generic()
-        info_two = self.getInfo_generic()
         self.assertEqual(
             info_one,
             info_one
         )
+    def test_object_not_equal_other(self):
+        info_one = self.getInfo_generic()
+        info_two = self.getInfo_generic()
         self.assertNotEqual(
             info_one,
             info_two
         )
+    def test_object_equal_self_variable_assignment(self):
+        info_one = self.getInfo_generic()
         a = info_one
         self.assertEqual(
             info_one,
             a
         )
+    def test_object_not_equal_other_variable_assignment(self):
+        info_one = self.getInfo_generic()
+        info_two = self.getInfo_generic()
+        a = info_one
         self.assertNotEqual(
             info_two,
             a

--- a/Lib/fontParts/test/test_kerning.py
+++ b/Lib/fontParts/test/test_kerning.py
@@ -19,12 +19,14 @@ class TestKerning(unittest.TestCase):
     # len
     # ---
 
-    def test_len(self):
+    def test_len_initial(self):
         kerning = self.getKerning_generic()
         self.assertEqual(
             len(kerning),
             4
         )
+    def test_len_clear(self):
+        kerning = self.getKerning_generic()
         kerning.clear()
         self.assertEqual(
             len(kerning),
@@ -60,11 +62,14 @@ class TestKerning(unittest.TestCase):
 
     def test_del(self):
         kerning = self.getKerning_generic()
+        # Be sure it is here before deleting
         self.assertEqual(
             ('A','A') in kerning,
             True
         )
+        # Delete
         del kerning[('A','A')]
+        # Test
         self.assertEqual(
             ('A','A') in kerning,
             False
@@ -74,20 +79,26 @@ class TestKerning(unittest.TestCase):
     # get
     # ---
 
-    def test_get(self):
+    def test_get_glyph_glyph(self):
         kerning = self.getKerning_generic()
         self.assertEqual(
             kerning[('A','A')],
             103
         )
+    def test_get_group_group(self):
+        kerning = self.getKerning_generic()
         self.assertEqual(
             kerning[("public.kern1.X", "public.kern2.X")],
             100
         )
+    def test_get_glyph_group(self):
+        kerning = self.getKerning_generic()
         self.assertEqual(
             kerning[("B", "public.kern2.X")],
             101
         )
+    def test_get_group_glyph(self):
+        kerning = self.getKerning_generic()
         self.assertEqual(
             kerning[("public.kern1.X", "B")],
             102
@@ -97,59 +108,33 @@ class TestKerning(unittest.TestCase):
     # set
     # ---
 
-    def test_set(self):
+    def test_set_glyph_glyph(self):
         kerning = self.getKerning_generic()
-        self.assertEqual(
-            kerning[('A','A')],
-            103
-        )
         kerning[('A','A')] = 1
         self.assertEqual(
             kerning[('A','A')],
             1
         )
-        self.assertEqual(
-            kerning[("public.kern1.X", "public.kern2.X")],
-            100
-        )
+    def test_set_group_group(self):
+        kerning = self.getKerning_generic()
         kerning[("public.kern1.X", "public.kern2.X")] = 2
         self.assertEqual(
             kerning[("public.kern1.X", "public.kern2.X")],
             2
         )
-        self.assertEqual(
-            kerning[("B", "public.kern2.X")],
-            101
-        )
+    def test_set_group_glyph(self):
+        kerning = self.getKerning_generic()
         kerning[("B", "public.kern2.X")] = 3
         self.assertEqual(
             kerning[("B", "public.kern2.X")],
             3
         )
-        self.assertEqual(
-            kerning[("public.kern1.X", "B")],
-            102
-        )
+    def test_set_group_glyph(self):
+        kerning = self.getKerning_generic()
         kerning[("public.kern1.X", "B")] = 4
         self.assertEqual(
             kerning[("public.kern1.X", "B")],
             4
-        )
-
-    # -----
-    # clear
-    # -----
-
-    def test_clear(self):
-        kerning = self.getKerning_generic()
-        self.assertEqual(
-            len(kerning),
-            4
-        )
-        kerning.clear()
-        self.assertEqual(
-            len(kerning),
-            0
         )
 
     # ----
@@ -166,22 +151,30 @@ class TestKerning(unittest.TestCase):
     # Equality
     # --------
 
-    def test_equal(self):
+    def test_object_equal_self(self):
         kerning_one = self.getKerning_generic()
-        kerning_two = self.getKerning_generic()
         self.assertEqual(
             kerning_one,
             kerning_one
         )
+    def test_object_not_equal_other(self):
+        kerning_one = self.getKerning_generic()
+        kerning_two = self.getKerning_generic()
         self.assertNotEqual(
             kerning_one,
             kerning_two
         )
+    def test_object_equal_self_variable_assignment(self):
+        kerning_one = self.getKerning_generic()
         a = kerning_one
         self.assertEqual(
             kerning_one,
             a
         )
+    def test_object_not_equal_other_variable_assignment(self):
+        kerning_one = self.getKerning_generic()
+        kerning_two = self.getKerning_generic()
+        a = kerning_one
         self.assertNotEqual(
             kerning_two,
             a

--- a/Lib/fontParts/test/test_kerning.py
+++ b/Lib/fontParts/test/test_kerning.py
@@ -122,7 +122,7 @@ class TestKerning(unittest.TestCase):
             kerning[("public.kern1.X", "public.kern2.X")],
             2
         )
-    def test_set_group_glyph(self):
+    def test_set_glyph_group(self):
         kerning = self.getKerning_generic()
         kerning[("B", "public.kern2.X")] = 3
         self.assertEqual(

--- a/Lib/fontParts/test/test_kerning.py
+++ b/Lib/fontParts/test/test_kerning.py
@@ -6,21 +6,21 @@ from fontParts.base import FontPartsError
 class TestKerning(unittest.TestCase):
 
     def getKerning_generic(self):
-        kerning, unrequested = self.objectGenerator("kerning")
+        kerning, _unrequested = self.objectGenerator("kerning")
         kerning.update({
             ("public.kern1.X", "public.kern2.X") : 100,
             ("B", "public.kern2.X") : 101,
             ("public.kern1.X", "B") : 102,
             ("A", "A") : 103,
         })
-        return kerning, unrequested
+        return kerning
 
     # ---
     # len
     # ---
 
     def test_len(self):
-        kerning, unrequested = self.getKerning_generic()
+        kerning = self.getKerning_generic()
         self.assertEqual(
             len(kerning),
             4
@@ -36,7 +36,7 @@ class TestKerning(unittest.TestCase):
     # --------
 
     def test_contains(self):
-        kerning, unrequested = self.getKerning_generic()
+        kerning = self.getKerning_generic()
         self.assertEqual(
             ('A','A') in kerning,
             True
@@ -59,7 +59,7 @@ class TestKerning(unittest.TestCase):
     # ---
 
     def test_del(self):
-        kerning, unrequested = self.getKerning_generic()
+        kerning = self.getKerning_generic()
         self.assertEqual(
             ('A','A') in kerning,
             True
@@ -75,7 +75,7 @@ class TestKerning(unittest.TestCase):
     # ---
 
     def test_get(self):
-        kerning, unrequested = self.getKerning_generic()
+        kerning = self.getKerning_generic()
         self.assertEqual(
             kerning[('A','A')],
             103
@@ -98,7 +98,7 @@ class TestKerning(unittest.TestCase):
     # ---
 
     def test_set(self):
-        kerning, unrequested = self.getKerning_generic()
+        kerning = self.getKerning_generic()
         self.assertEqual(
             kerning[('A','A')],
             103
@@ -141,7 +141,7 @@ class TestKerning(unittest.TestCase):
     # -----
 
     def test_clear(self):
-        kerning, unrequested = self.getKerning_generic()
+        kerning = self.getKerning_generic()
         self.assertEqual(
             len(kerning),
             4
@@ -156,7 +156,7 @@ class TestKerning(unittest.TestCase):
     # Hash
     # ----
     def test_hash(self):
-        kerning, unrequested = self.getKerning_generic()
+        kerning = self.getKerning_generic()
         self.assertEqual(
             isinstance(kerning, collections.Hashable),
             False
@@ -167,8 +167,8 @@ class TestKerning(unittest.TestCase):
     # --------
 
     def test_equal(self):
-        kerning_one, unrequested = self.getKerning_generic()
-        kerning_two, unrequested = self.getKerning_generic()
+        kerning_one = self.getKerning_generic()
+        kerning_two = self.getKerning_generic()
         self.assertEqual(
             kerning_one,
             kerning_one

--- a/Lib/fontParts/test/test_layer.py
+++ b/Lib/fontParts/test/test_layer.py
@@ -10,15 +10,15 @@ class TestLayer(unittest.TestCase):
     # ------
 
     def getLayer_glyphs(self):
-        layer, unrequested = self.objectGenerator("layer")
+        layer, _unrequested = self.objectGenerator("layer")
         for name in "ABCD":
             glyph = layer.newGlyph(name)
-        return layer, unrequested
+        return layer
 
     # len
 
     def test_len(self):
-        layer, unrequested = self.getLayer_glyphs()
+        layer = self.getLayer_glyphs()
         self.assertEqual(
             len(layer),
             4
@@ -28,7 +28,7 @@ class TestLayer(unittest.TestCase):
     # Hash
     # ----
     def test_hash(self):
-        layer, unrequested = self.getLayer_glyphs()
+        layer = self.getLayer_glyphs()
         self.assertEqual(
             isinstance(layer, collections.Hashable),
             False
@@ -39,8 +39,8 @@ class TestLayer(unittest.TestCase):
     # --------
 
     def test_equal(self):
-        layer_one, unrequested = self.getLayer_glyphs()
-        layer_two, unrequested = self.getLayer_glyphs()
+        layer_one = self.getLayer_glyphs()
+        layer_two = self.getLayer_glyphs()
         self.assertEqual(
             layer_one,
             layer_one

--- a/Lib/fontParts/test/test_layer.py
+++ b/Lib/fontParts/test/test_layer.py
@@ -15,8 +15,6 @@ class TestLayer(unittest.TestCase):
             glyph = layer.newGlyph(name)
         return layer
 
-    # len
-
     def test_len(self):
         layer = self.getLayer_glyphs()
         self.assertEqual(
@@ -38,22 +36,30 @@ class TestLayer(unittest.TestCase):
     # Equality
     # --------
 
-    def test_equal(self):
+    def test_object_equal_self(self):
         layer_one = self.getLayer_glyphs()
-        layer_two = self.getLayer_glyphs()
         self.assertEqual(
             layer_one,
             layer_one
         )
+    def test_object_not_equal_other(self):
+        layer_one = self.getLayer_glyphs()
+        layer_two = self.getLayer_glyphs()
         self.assertNotEqual(
             layer_one,
             layer_two
         )
+    def test_object_equal_self_variable_assignment(self):
+        layer_one = self.getLayer_glyphs()
         a = layer_one
         self.assertEqual(
             layer_one,
             a
         )
+    def test_object_not_equal_self_variable_assignment(self):
+        layer_one = self.getLayer_glyphs()
+        layer_two = self.getLayer_glyphs()
+        a = layer_one
         self.assertNotEqual(
             layer_two,
             a

--- a/Lib/fontParts/test/test_point.py
+++ b/Lib/fontParts/test/test_point.py
@@ -17,40 +17,47 @@ class TestPoint(unittest.TestCase):
     # Type
     # ----
 
-    def test_type(self):
+    def test_get(self):
         point = self.getPoint_generic()
         # get
         self.assertEqual(
             point.type,
             "line"
         )
-        # set: move
+    def test_set_move(self):
+        point = self.getPoint_generic()
         point.type = "move"
         self.assertEqual(
             point.type,
             "move"
         )
-        # set: curve
+    def test_set_curve(self):
+        point = self.getPoint_generic()
         point.type = "curve"
         self.assertEqual(
             point.type,
             "curve"
         )
-        # set: qcurve
+    def test_set_wcurve(self):
+        point = self.getPoint_generic()
         point.type = "qcurve"
         self.assertEqual(
             point.type,
             "qcurve"
         )
-        # set: offcurve
+    def test_set_offcurve(self):
+        point = self.getPoint_generic()
         point.type = "offcurve"
         self.assertEqual(
             point.type,
             "offcurve"
         )
-        # set: invalid
+    def test_set_invalid_point_type_string(self):
+        point = self.getPoint_generic()
         with self.assertRaises(FontPartsError):
             point.type = "xxx"
+    def test_set_invalid_point_type_int(self):
+        point = self.getPoint_generic()
         with self.assertRaises(FontPartsError):
             point.type = 123
 
@@ -68,22 +75,30 @@ class TestPoint(unittest.TestCase):
     # Equality
     # --------
 
-    def test_equal(self):
+    def test_object_equal_self(self):
         point_one = self.getPoint_generic()
-        point_two = self.getPoint_generic()
         self.assertEqual(
             point_one,
             point_one
         )
+    def test_object_not_equal_other(self):
+        point_one = self.getPoint_generic()
+        point_two = self.getPoint_generic()
         self.assertNotEqual(
             point_one,
             point_two
         )
+    def test_object_equal_self_variable_assignment(self):
+        point_one = self.getPoint_generic()
         a = point_one
         self.assertEqual(
             point_one,
             a
         )
+    def test_object_not_equal_other_variable_assignment(self):
+        point_one = self.getPoint_generic()
+        point_two = self.getPoint_generic()
+        a = point_one
         self.assertNotEqual(
             point_two,
             a

--- a/Lib/fontParts/test/test_point.py
+++ b/Lib/fontParts/test/test_point.py
@@ -6,19 +6,19 @@ from fontParts.base import FontPartsError
 class TestPoint(unittest.TestCase):
 
     def getPoint_generic(self):
-        contour, unrequested = self.objectGenerator("contour")
-        unrequested.append(contour)
+        contour, _unrequested = self.objectGenerator("contour")
+        _unrequested.append(contour)
         contour.appendPoint((0, 0), "move")
         contour.appendPoint((101, 202), "line")
         point = contour.points[1]
-        return point, unrequested
+        return point
 
     # ----
     # Type
     # ----
 
     def test_type(self):
-        point, unrequested = self.getPoint_generic()
+        point = self.getPoint_generic()
         # get
         self.assertEqual(
             point.type,
@@ -58,7 +58,7 @@ class TestPoint(unittest.TestCase):
     # Hash
     # ----
     def test_hash(self):
-        point, unrequested = self.getPoint_generic()
+        point = self.getPoint_generic()
         self.assertEqual(
             isinstance(point, collections.Hashable),
             False
@@ -69,8 +69,8 @@ class TestPoint(unittest.TestCase):
     # --------
 
     def test_equal(self):
-        point_one, unrequested = self.getPoint_generic()
-        point_two, unrequested = self.getPoint_generic()
+        point_one = self.getPoint_generic()
+        point_two = self.getPoint_generic()
         self.assertEqual(
             point_one,
             point_one

--- a/Lib/fontParts/test/test_segment.py
+++ b/Lib/fontParts/test/test_segment.py
@@ -103,7 +103,7 @@ class TestSegment(unittest.TestCase):
             types,
             ("offcurve", "offcurve", "qcurve")
         )
-    def test_curve_pt_x_y(self):
+    def test_qcurve_pt_x_y(self):
         segment = self.getSegment_line()
         segment.type = "qcurve"
         coordinates = tuple((point.x, point.y) for point in segment.points)

--- a/Lib/fontParts/test/test_segment.py
+++ b/Lib/fontParts/test/test_segment.py
@@ -6,12 +6,12 @@ from fontParts.base import FontPartsError
 class TestSegment(unittest.TestCase):
 
     def getSegment_line(self):
-        contour, unrequested = self.objectGenerator("contour")
-        unrequested.append(contour)
+        contour, _unrequested = self.objectGenerator("contour")
+        _unrequested.append(contour)
         contour.appendPoint((0, 0), "move")
         contour.appendPoint((101, 202), "line")
         segment = contour[1]
-        return segment, unrequested
+        return segment
 
     # ----
     # Type
@@ -19,13 +19,13 @@ class TestSegment(unittest.TestCase):
 
     def test_typeLine(self):
         # get
-        segment, unrequested = self.getSegment_line()
+        segment = self.getSegment_line()
         self.assertEqual(
             segment.type,
             "line"
         )
         # set: move
-        segment, unrequested = self.getSegment_line()
+        segment = self.getSegment_line()
         segment.type = "move"
         self.assertEqual(
             segment.type,
@@ -44,7 +44,7 @@ class TestSegment(unittest.TestCase):
             (101, 202)
         )
         # set: curve
-        segment, unrequested = self.getSegment_line()
+        segment = self.getSegment_line()
         segment.type = "curve"
         self.assertEqual(
             segment.type,
@@ -65,7 +65,7 @@ class TestSegment(unittest.TestCase):
             ((0, 0), (101, 202), (101, 202))
         )
         # set: qcurve
-        segment, unrequested = self.getSegment_line()
+        segment = self.getSegment_line()
         segment.type = "qcurve"
         self.assertEqual(
             segment.type,
@@ -96,7 +96,7 @@ class TestSegment(unittest.TestCase):
     # Hash
     # ----
     def test_hash(self):
-        segment, unrequested = self.getSegment_line()
+        segment = self.getSegment_line()
         self.assertEqual(
             isinstance(segment, collections.Hashable),
             False
@@ -107,8 +107,8 @@ class TestSegment(unittest.TestCase):
     # --------
 
     def test_equal(self):
-        segment_one, unrequested = self.getSegment_line()
-        segment_two, unrequested = self.getSegment_line()
+        segment_one = self.getSegment_line()
+        segment_two = self.getSegment_line()
         self.assertEqual(
             segment_one,
             segment_one

--- a/Lib/fontParts/test/test_segment.py
+++ b/Lib/fontParts/test/test_segment.py
@@ -17,77 +17,106 @@ class TestSegment(unittest.TestCase):
     # Type
     # ----
 
-    def test_typeLine(self):
-        # get
+    def test_type_get(self):
         segment = self.getSegment_line()
         self.assertEqual(
             segment.type,
             "line"
         )
-        # set: move
+    def test_set_move(self):
         segment = self.getSegment_line()
         segment.type = "move"
         self.assertEqual(
             segment.type,
             "move"
         )
+    def test_len_move(self):
+        segment = self.getSegment_line()
+        segment.type = "move"
         self.assertEqual(
             len(segment.points),
             1
         )
+    def test_oncuve_type_move(self):
+        segment = self.getSegment_line()
+        segment.type = "move"
         self.assertEqual(
             segment.onCurve.type,
             "move"
         )
+    def test_oncuve_x_y(self):
+        segment = self.getSegment_line()
+        segment.type = "move"
         self.assertEqual(
             (segment.onCurve.x, segment.onCurve.y),
             (101, 202)
         )
-        # set: curve
+    def test_set_curve(self):
         segment = self.getSegment_line()
         segment.type = "curve"
         self.assertEqual(
             segment.type,
             "curve"
         )
+    def test_len_curve(self):
+        segment = self.getSegment_line()
+        segment.type = "curve"
         self.assertEqual(
             len(segment.points),
             3
         )
+    def test_curve_pt_types(self):
+        segment = self.getSegment_line()
+        segment.type = "curve"
         types = tuple(point.type for point in segment.points)
         self.assertEqual(
             types,
             ("offcurve", "offcurve", "curve")
         )
+    def test_curve_pt_x_y(self):
+        segment = self.getSegment_line()
+        segment.type = "curve"
         coordinates = tuple((point.x, point.y) for point in segment.points)
         self.assertEqual(
             coordinates,
             ((0, 0), (101, 202), (101, 202))
         )
-        # set: qcurve
+    def test_set_qcurve(self):
         segment = self.getSegment_line()
         segment.type = "qcurve"
         self.assertEqual(
             segment.type,
             "qcurve"
         )
+    def test_len_qcurve(self):
+        segment = self.getSegment_line()
+        segment.type = "qcurve"
         self.assertEqual(
             len(segment.points),
             3
         )
+    def test_qcurve_pt_types(self):
+        segment = self.getSegment_line()
+        segment.type = "qcurve"
         types = tuple(point.type for point in segment.points)
         self.assertEqual(
             types,
             ("offcurve", "offcurve", "qcurve")
         )
+    def test_curve_pt_x_y(self):
+        segment = self.getSegment_line()
+        segment.type = "qcurve"
         coordinates = tuple((point.x, point.y) for point in segment.points)
         self.assertEqual(
             coordinates,
             ((0, 0), (101, 202), (101, 202))
         )
-        # set: invalid
+    def test_set_invalid_segment_type_string(self):
+        segment = self.getSegment_line()
         with self.assertRaises(FontPartsError):
             segment.type = "xxx"
+    def test_set_invalid_segment_type_int(self):
+        segment = self.getSegment_line()
         with self.assertRaises(FontPartsError):
             segment.type = 123
 
@@ -106,22 +135,30 @@ class TestSegment(unittest.TestCase):
     # Equality
     # --------
 
-    def test_equal(self):
+    def test_object_equal_self(self):
         segment_one = self.getSegment_line()
-        segment_two = self.getSegment_line()
         self.assertEqual(
             segment_one,
             segment_one
         )
+    def test_object_not_equal_other(self):
+        segment_one = self.getSegment_line()
+        segment_two = self.getSegment_line()
         self.assertNotEqual(
             segment_one,
             segment_two
         )
+    def test_object_equal_self_variable_assignment(self):
+        segment_one = self.getSegment_line()
         a = segment_one
         self.assertEqual(
             segment_one,
             a
         )
+    def test_object_not_equal_other_variable_assignment(self):
+        segment_one = self.getSegment_line()
+        segment_two = self.getSegment_line()
+        a = segment_one
         self.assertNotEqual(
             segment_two,
             a


### PR DESCRIPTION
Based on a conversation with @cjchapman, reworked tests to have one method per thing testing, also set the unrequested to a private variable that isn't passed to tests, as we *don't* want any of that tested.