### PR TITLE
Simplify error types to use base error types 

### DIFF
--- a/Lib/fontParts/base/anchor.py
+++ b/Lib/fontParts/base/anchor.py
@@ -3,13 +3,12 @@ from fontParts.base import normalizers
 from fontParts.base.base import (
     BaseObject, TransformationMixin, InterpolationMixin, SelectionMixin,
     dynamicProperty, PointPositionMixin, reference)
-from fontParts.base.errors import FontPartsError
 from fontParts.base.compatibility import AnchorCompatibilityReporter
 from fontParts.base.color import Color
 from fontParts.base.deprecated import DeprecatedAnchor, RemovedAnchor
 
 
-class BaseAnchor(BaseObject, TransformationMixin, DeprecatedAnchor, 
+class BaseAnchor(BaseObject, TransformationMixin, DeprecatedAnchor,
     RemovedAnchor, PointPositionMixin, InterpolationMixin, SelectionMixin):
 
     """

--- a/Lib/fontParts/base/bPoint.py
+++ b/Lib/fontParts/base/bPoint.py
@@ -1,5 +1,4 @@
 from fontTools.misc import transform
-from fontParts.base.errors import FontPartsError
 from fontParts.base.base import (
     BaseObject, TransformationMixin, SelectionMixin,
     dynamicProperty, reference
@@ -200,9 +199,9 @@ class BaseBPoint(BaseObject, TransformationMixin, SelectionMixin,
         x, y = absoluteBCPIn(self.anchor, value)
         segment = self._segment
         if segment.type == "move" and value != (0, 0):
-            raise FontPartsError(("Cannot set the bcpIn for the first "
-                                  "point in an open contour.")
-                                 )
+            raise ValueError(("Cannot set the bcpIn for the first "
+                              "point in an open contour.")
+                             )
         else:
             offCurves = segment.offCurve
             if offCurves:
@@ -254,9 +253,9 @@ class BaseBPoint(BaseObject, TransformationMixin, SelectionMixin,
         segment = self._segment
         nextSegment = self._nextSegment
         if nextSegment.type == "move" and value != (0, 0):
-            raise FontPartsError(("Cannot set the bcpOut for the last "
-                                  "point in an open contour.")
-                                 )
+            raise ValueError(("Cannot set the bcpOut for the last "
+                              "point in an open contour.")
+                             )
         else:
             offCurves = nextSegment.offCurve
             if offCurves:
@@ -298,8 +297,8 @@ class BaseBPoint(BaseObject, TransformationMixin, SelectionMixin,
         elif typ in ("move", "line", "curve"):
             bType = "corner"
         else:
-            raise FontPartsError("A %s point can not be converted to a bPoint."
-                                 % typ)
+            raise TypeError("A %s point can not be converted to a bPoint."
+                            % typ)
         return bType
 
     def _set_type(self, value):

--- a/Lib/fontParts/base/bPoint.py
+++ b/Lib/fontParts/base/bPoint.py
@@ -3,6 +3,7 @@ from fontParts.base.base import (
     BaseObject, TransformationMixin, SelectionMixin,
     dynamicProperty, reference
 )
+from fontParts.base.errors import FontPartsError
 from fontParts.base import normalizers
 from fontParts.base.deprecated import DeprecatedBPoint, RemovedBPoint
 
@@ -199,9 +200,9 @@ class BaseBPoint(BaseObject, TransformationMixin, SelectionMixin,
         x, y = absoluteBCPIn(self.anchor, value)
         segment = self._segment
         if segment.type == "move" and value != (0, 0):
-            raise ValueError(("Cannot set the bcpIn for the first "
-                              "point in an open contour.")
-                             )
+            raise FontPartsError(("Cannot set the bcpIn for the first "
+                                  "point in an open contour.")
+                                 )
         else:
             offCurves = segment.offCurve
             if offCurves:
@@ -253,9 +254,9 @@ class BaseBPoint(BaseObject, TransformationMixin, SelectionMixin,
         segment = self._segment
         nextSegment = self._nextSegment
         if nextSegment.type == "move" and value != (0, 0):
-            raise ValueError(("Cannot set the bcpOut for the last "
-                              "point in an open contour.")
-                             )
+            raise FontPartsError(("Cannot set the bcpOut for the last "
+                                  "point in an open contour.")
+                                 )
         else:
             offCurves = nextSegment.offCurve
             if offCurves:
@@ -297,8 +298,8 @@ class BaseBPoint(BaseObject, TransformationMixin, SelectionMixin,
         elif typ in ("move", "line", "curve"):
             bType = "corner"
         else:
-            raise TypeError("A %s point can not be converted to a bPoint."
-                            % typ)
+            raise FontPartsError("A %s point can not be converted to a bPoint."
+                                 % typ)
         return bType
 
     def _set_type(self, value):

--- a/Lib/fontParts/base/base.py
+++ b/Lib/fontParts/base/base.py
@@ -216,7 +216,7 @@ class BaseObject(object):
         This exception needs to be raised frequently by
         the base classes. So, it's here for convenience.
         """
-        raise FontPartsError(
+        raise NotImplementedError(
             "The {className} subclass does not implement this method."
             .format(className=self.__class__.__name__)
         )
@@ -631,7 +631,7 @@ class InterpolationMixin(object):
         Evaluate interpolation compatibility with other.
         """
         if not isinstance(other, cls):
-            raise FontPartsError(
+            raise TypeError(
                 """Compatibility between an instance of %r and an \
                 instance of %r can not be checked."""
                 % (cls.__name__, other.__class__.__name__))

--- a/Lib/fontParts/base/compatibility.py
+++ b/Lib/fontParts/base/compatibility.py
@@ -4,6 +4,7 @@ from fontParts.base.base import dynamicProperty
 # Base
 # ----
 
+
 class BaseCompatibilityReporter(object):
 
     objectName = "Base"

--- a/Lib/fontParts/base/contour.py
+++ b/Lib/fontParts/base/contour.py
@@ -528,7 +528,7 @@ class BaseContour(BaseObject, TransformationMixin, InterpolationMixin, Selection
             segment = self.segments.index(segment)
         segment = normalizers.normalizeIndex(segment)
         if segment >= self._len__segments():
-            raise FontPartsError("No segment located at index %d." % segment)
+            raise ValueError("No segment located at index %d." % segment)
         self._removeSegment(segment, **kwargs)
 
     def _removeSegment(self, segment, **kwargs):
@@ -556,7 +556,7 @@ class BaseContour(BaseObject, TransformationMixin, InterpolationMixin, Selection
         if segmentIndex == 0:
             return
         if segmentIndex >= len(segments):
-            raise FontPartsError("The contour does not contain a segment at index %d" % segmentIndex)
+            raise ValueError("The contour does not contain a segment at index %d" % segmentIndex)
         self._setStartSegment(segmentIndex, **kwargs)
 
     def _setStartSegment(self, segmentIndex, **kwargs):
@@ -659,7 +659,7 @@ class BaseContour(BaseObject, TransformationMixin, InterpolationMixin, Selection
         # insert a curve point that we can work with
         nextSegment = segments[index]
         if nextSegment.type not in ("move", "line", "curve"):
-            raise FontPartsError("Unknonw segment type (%s) in contour." % nextSegment.type)
+            raise ValueError("Unknown segment type (%s) in contour." % nextSegment.type)
         if nextSegment.type == "move":
             prevSegment = segments[index - 1]
             prevOn = prevSegment.onCurve
@@ -752,7 +752,7 @@ class BaseContour(BaseObject, TransformationMixin, InterpolationMixin, Selection
             bPoint = bPoint.index
         bPoint = normalizers.normalizeIndex(bPoint)
         if bPoint >= self._len__points():
-            raise FontPartsError("No bPoint located at index %d." % bPoint)
+            raise ValueError("No bPoint located at index %d." % bPoint)
         self._removeBPoint(bPoint, **kwargs)
 
     def _removeBPoint(self, index, **kwargs):
@@ -808,7 +808,7 @@ class BaseContour(BaseObject, TransformationMixin, InterpolationMixin, Selection
     def _getitem__points(self, index):
         index = normalizers.normalizeIndex(index)
         if index >= self._len__points():
-            raise FontPartsError("No point located at index %d." % index)
+            raise ValueError("No point located at index %d." % index)
         point = self._getPoint(index)
         self._setContourInPoint(point)
         return point
@@ -871,7 +871,7 @@ class BaseContour(BaseObject, TransformationMixin, InterpolationMixin, Selection
             point = self.points.index(point)
         point = normalizers.normalizeIndex(point)
         if point >= self._len__points():
-            raise FontPartsError("No point located at index %d." % point)
+            raise ValueError("No point located at index %d." % point)
         self._removePoint(point, **kwargs)
 
     def _removePoint(self, index, **kwargs):

--- a/Lib/fontParts/base/deprecated.py
+++ b/Lib/fontParts/base/deprecated.py
@@ -6,6 +6,7 @@ A collection of deprecated roboFab methods.
 Those methods are added to keep scripts and code compatible.
 """
 
+
 class RemovedWarning(DeprecationWarning):
     """Warning for things removed from FontParts that were in RoboFab"""
 
@@ -25,12 +26,14 @@ class DeprecatedBase(object):
 
     def update(self):
         objName = self.__class__.__name__.replace("Deprecated", "")
-        warnings.warn("'%s.update': use %s.changed()" % (objName, objName), DeprecationWarning)
+        warnings.warn("'%s.update': use %s.changed()"
+                      % (objName, objName), DeprecationWarning)
         self.changed()
 
     def setChanged(self):
         objName = self.__class__.__name__.replace("Deprecated", "")
-        warnings.warn("'%s.setChanged': use %s.changed()" % (objName, objName), DeprecationWarning)
+        warnings.warn("'%s.setChanged': use %s.changed()"
+                      % (objName, objName), DeprecationWarning)
         self.changed()
 
 
@@ -42,17 +45,20 @@ class DeprecatedTransformation(object):
 
     def move(self, *args, **kwargs):
         objName = self.__class__.__name__.replace("Deprecated", "")
-        warnings.warn("'%s.move()': use %s.moveBy()" % (objName, objName), DeprecationWarning)
+        warnings.warn("'%s.move()': use %s.moveBy()"
+                      % (objName, objName), DeprecationWarning)
         self.moveBy(*args, **kwargs)
 
     def translate(self, *args, **kwargs):
         objName = self.__class__.__name__.replace("Deprecated", "")
-        warnings.warn("'%s.translate()': use %s.moveBy()" % (objName, objName), DeprecationWarning)
+        warnings.warn("'%s.translate()': use %s.moveBy()"
+                      % (objName, objName), DeprecationWarning)
         self.moveBy(*args, **kwargs)
 
     def scale(self, *args, **kwargs):
         objName = self.__class__.__name__.replace("Deprecated", "")
-        warnings.warn("'%s.scale()': use %s.scaleBy()" % (objName, objName), DeprecationWarning)
+        warnings.warn("'%s.scale()': use %s.scaleBy()"
+                      % (objName, objName), DeprecationWarning)
         if "center" in kwargs:
             kwargs["origin"] = kwargs["center"]
             del kwargs["center"]
@@ -60,7 +66,8 @@ class DeprecatedTransformation(object):
 
     def rotate(self, *args, **kwargs):
         objName = self.__class__.__name__.replace("Deprecated", "")
-        warnings.warn("'%s.rotate()': use %s.rotateBy()" % (objName, objName), DeprecationWarning)
+        warnings.warn("'%s.rotate()': use %s.rotateBy()"
+                      % (objName, objName), DeprecationWarning)
         if "offset" in kwargs:
             kwargs["origin"] = kwargs["offset"]
             del kwargs["offset"]
@@ -68,12 +75,14 @@ class DeprecatedTransformation(object):
 
     def transform(self, *args, **kwargs):
         objName = self.__class__.__name__.replace("Deprecated", "")
-        warnings.warn("'%s.transform()': use %s.transformBy()" % (objName, objName), DeprecationWarning)
+        warnings.warn("'%s.transform()': use %s.transformBy()"
+                      % (objName, objName), DeprecationWarning)
         self.transformBy(*args, **kwargs)
 
     def skew(self, *args, **kwargs):
         objName = self.__class__.__name__.replace("Deprecated", "")
-        warnings.warn("'%s.skew()': use %s.skewBy()" % (objName, objName), DeprecationWarning)
+        warnings.warn("'%s.skew()': use %s.skewBy()"
+                      % (objName, objName), DeprecationWarning)
         if "offset" in kwargs:
             kwargs["origin"] = kwargs["offset"]
             del kwargs["offset"]

--- a/Lib/fontParts/base/features.py
+++ b/Lib/fontParts/base/features.py
@@ -1,4 +1,3 @@
-from fontParts.base.errors import FontPartsError
 from fontParts.base.base import BaseObject, dynamicProperty, reference
 from fontParts.base import normalizers
 from fontParts.base.deprecated import DeprecatedFeatures, RemovedFeatures

--- a/Lib/fontParts/base/font.py
+++ b/Lib/fontParts/base/font.py
@@ -43,7 +43,7 @@ class BaseFont(_BaseGlyphVendor, InterpolationMixin, DeprecatedFont, RemovedFont
         """
         Allow font object to be used as a key
         in a dictionary.
-        
+
         Subclasses may override this method.
         """
         return id(self.naked())
@@ -195,15 +195,18 @@ class BaseFont(_BaseGlyphVendor, InterpolationMixin, DeprecatedFont, RemovedFont
            the original OpenType font.
         """
         if path is None and self.path is None:
-            raise FontPartsError("The font cannot be saved because no file location has been given.")
+            raise IOError(("The font cannot be saved because no file "
+                          "location has been given."))
         if path is not None:
             path = normalizers.normalizeFilePath(path)
         showProgress = bool(showProgress)
         if formatVersion is not None:
             formatVersion = normalizers.normalizeFileFormatVersion(formatVersion)
-        self._save(path=path, showProgress=showProgress, formatVersion=formatVersion)
+        self._save(path=path, showProgress=showProgress,
+                   formatVersion=formatVersion)
 
-    def _save(self, path=None, showProgress=False, formatVersion=None, **kwargs):
+    def _save(self, path=None, showProgress=False,
+              formatVersion=None, **kwargs):
         """
         This is the environment implementation of
         :meth:`BaseFont.save`. **path** will be a
@@ -324,18 +327,20 @@ class BaseFont(_BaseGlyphVendor, InterpolationMixin, DeprecatedFont, RemovedFont
         """
 
         if format is None:
-            raise FontPartsError("The format must be defined when generating.")
+            raise TypeError("The format must be defined when generating.")
         elif not isinstance(format, basestring):
-            raise FontPartsError("The format must be defined as a string.")
+            raise TypeError("The format must be defined as a string.")
         ext = self.generateFormatToExtension(format, "." + format)
         if path is None and self.path is None:
-            raise FontPartsError("The file cannot be generated because an output path was not defined.")
+            raise IOError(("The file cannot be generated because an "
+                           "output path was not defined."))
         elif path is None:
             path = os.path.splitext(self.path)[0]
             path += ext
         elif os.path.isdir(path):
             if self.path is None:
-                raise FontPartsError("The file cannot be generated because the file does not have a path.")
+                raise IOError(("The file cannot be generated because "
+                               "the file does not have a path."))
             fileName = os.path.basename(self.path)
             fileName += ext
             path = os.path.join(path, fileName)
@@ -641,7 +646,7 @@ class BaseFont(_BaseGlyphVendor, InterpolationMixin, DeprecatedFont, RemovedFont
         """
         name = normalizers.normalizeLayerName(name)
         if name not in self.layerOrder:
-            raise FontPartsError("No layer with the name '%s' exists." % name)
+            raise ValueError("No layer with the name '%s' exists." % name)
 
         layer = self._getLayer(name)
         self._setFontInLayer(layer)
@@ -716,7 +721,7 @@ class BaseFont(_BaseGlyphVendor, InterpolationMixin, DeprecatedFont, RemovedFont
         """
         name = normalizers.normalizeLayerName(name)
         if name not in self.layerOrder:
-            raise FontPartsError("No layer with the name '%s' exists." % name)
+            raise ValueError("No layer with the name '%s' exists." % name)
         self._removeLayer(name)
 
     def _removeLayer(self, name, **kwargs):
@@ -950,7 +955,7 @@ class BaseFont(_BaseGlyphVendor, InterpolationMixin, DeprecatedFont, RemovedFont
     def _getitem__guidelines(self, index):
         index = normalizers.normalizeGuidelineIndex(index)
         if index >= self._len__guidelines():
-            raise FontPartsError("No guideline located at index %d." % index)
+            raise ValueError("No guideline located at index %d." % index)
         guideline = self._getGuideline(index)
         self._setFontInGuideline(guideline)
         return guideline
@@ -968,7 +973,7 @@ class BaseFont(_BaseGlyphVendor, InterpolationMixin, DeprecatedFont, RemovedFont
         for i, other in enumerate(self.guidelines):
             if guideline == other:
                 return i
-        raise FontPartsError("The guideline could not be found.")
+        raise ValueError("The guideline could not be found.")
 
     def appendGuideline(self, position, angle, name=None, color=None):
         """
@@ -1026,7 +1031,7 @@ class BaseFont(_BaseGlyphVendor, InterpolationMixin, DeprecatedFont, RemovedFont
             index = self._getGuidelineIndex(guideline)
         index = normalizers.normalizeGuidelineIndex(index)
         if index >= self._len__guidelines():
-            raise FontPartsError("No guideline located at index %d." % index)
+            raise ValueError("No guideline located at index %d." % index)
         self._removeGuideline(index)
 
     def _removeGuideline(self, index, **kwargs):
@@ -1081,9 +1086,9 @@ class BaseFont(_BaseGlyphVendor, InterpolationMixin, DeprecatedFont, RemovedFont
         """
         factor = normalizers.normalizeInterpolationFactor(factor)
         if not isinstance(minFont, BaseFont):
-            raise FontPartsError("Interpolation to an instance of %r can not be performed from an instance of %r." % (self.__class__.__name__, minFont.__class__.__name__))
+            raise TypeError("Interpolation to an instance of %r can not be performed from an instance of %r." % (self.__class__.__name__, minFont.__class__.__name__))
         if not isinstance(maxFont, BaseFont):
-            raise FontPartsError("Interpolation to an instance of %r can not be performed from an instance of %r." % (self.__class__.__name__, maxFont.__class__.__name__))
+            raise TypeError("Interpolation to an instance of %r can not be performed from an instance of %r." % (self.__class__.__name__, maxFont.__class__.__name__))
         round = normalizers.normalizeBoolean(round)
         suppressError = normalizers.normalizeBoolean(suppressError)
         self._interpolate(factor, minFont, maxFont, round=round, suppressError=suppressError)

--- a/Lib/fontParts/base/font.py
+++ b/Lib/fontParts/base/font.py
@@ -327,7 +327,7 @@ class BaseFont(_BaseGlyphVendor, InterpolationMixin, DeprecatedFont, RemovedFont
         """
 
         if format is None:
-            raise TypeError("The format must be defined when generating.")
+            raise ValueError("The format must be defined when generating.")
         elif not isinstance(format, basestring):
             raise TypeError("The format must be defined as a string.")
         ext = self.generateFormatToExtension(format, "." + format)
@@ -973,7 +973,7 @@ class BaseFont(_BaseGlyphVendor, InterpolationMixin, DeprecatedFont, RemovedFont
         for i, other in enumerate(self.guidelines):
             if guideline == other:
                 return i
-        raise ValueError("The guideline could not be found.")
+        raise FontPartsError("The guideline could not be found.")
 
     def appendGuideline(self, position, angle, name=None, color=None):
         """

--- a/Lib/fontParts/base/glyph.py
+++ b/Lib/fontParts/base/glyph.py
@@ -41,7 +41,7 @@ class BaseGlyph(BaseObject, TransformationMixin, InterpolationMixin, SelectionMi
         """
         Allow glyph object to be used as a key
         in a dictionary.
-        
+
         Subclasses may override this method.
         """
         return id(self.naked())
@@ -165,7 +165,7 @@ class BaseGlyph(BaseObject, TransformationMixin, InterpolationMixin, SelectionMi
         value = normalizers.normalizeGlyphName(value)
         layer = self.layer
         if layer is not None and value in layer:
-            raise FontPartsError("A glyph with the name '%s' already exists." % value)
+            raise ValueError("A glyph with the name '%s' already exists." % value)
         self._set_name(value)
 
     def _get_name(self):
@@ -754,7 +754,7 @@ class BaseGlyph(BaseObject, TransformationMixin, InterpolationMixin, SelectionMi
         """
         index = normalizers.normalizeContourIndex(index)
         if index >= len(self):
-            raise FontPartsError("No contour located at index %d." % index)
+            raise ValueError("No contour located at index %d." % index)
         contour = self._getContour(index)
         self._setGlyphInContour(contour)
         return contour
@@ -773,7 +773,7 @@ class BaseGlyph(BaseObject, TransformationMixin, InterpolationMixin, SelectionMi
         for i, other in enumerate(self.contours):
             if contour == other:
                 return i
-        raise FontPartsError("The contour could not be found.")
+        raise ValueError("The contour could not be found.")
 
     def appendContour(self, contour, offset=None):
         """
@@ -824,7 +824,7 @@ class BaseGlyph(BaseObject, TransformationMixin, InterpolationMixin, SelectionMi
             index = self._getContourIndex(contour)
         index = normalizers.normalizeContourIndex(index)
         if index >= len(self):
-            raise FontPartsError("No contour located at index %d." % index)
+            raise ValueError("No contour located at index %d." % index)
         self._removeContour(index)
 
     def _removeContour(self, index, **kwargs):
@@ -902,7 +902,7 @@ class BaseGlyph(BaseObject, TransformationMixin, InterpolationMixin, SelectionMi
     def _getitem__components(self, index):
         index = normalizers.normalizeComponentIndex(index)
         if index >= self._len__components():
-            raise FontPartsError("No component located at index %d." % index)
+            raise ValueError("No component located at index %d." % index)
         component = self._getComponent(index)
         self._setGlyphInComponent(component)
         return component
@@ -921,7 +921,7 @@ class BaseGlyph(BaseObject, TransformationMixin, InterpolationMixin, SelectionMi
         for i, other in enumerate(self.components):
             if component == other:
                 return i
-        raise FontPartsError("The component could not be found.")
+        raise ValueError("The component could not be found.")
 
     def appendComponent(self, baseGlyph, offset=None, scale=None):
         """
@@ -985,7 +985,7 @@ class BaseGlyph(BaseObject, TransformationMixin, InterpolationMixin, SelectionMi
             index = self._getComponentIndex(component)
         index = normalizers.normalizeComponentIndex(index)
         if index >= self._len__components():
-            raise FontPartsError("No component located at index %d." % index)
+            raise ValueError("No component located at index %d." % index)
         self._removeComponent(index)
 
     def _removeComponent(self, index, **kwargs):
@@ -1064,7 +1064,7 @@ class BaseGlyph(BaseObject, TransformationMixin, InterpolationMixin, SelectionMi
     def _getitem__anchors(self, index):
         index = normalizers.normalizeAnchorIndex(index)
         if index >= self._len__anchors():
-            raise FontPartsError("No anchor located at index %d." % index)
+            raise ValueError("No anchor located at index %d." % index)
         anchor = self._getAnchor(index)
         self._setGlyphInAnchor(anchor)
         return anchor
@@ -1083,7 +1083,7 @@ class BaseGlyph(BaseObject, TransformationMixin, InterpolationMixin, SelectionMi
         for i, other in enumerate(self.anchors):
             if anchor == other:
                 return i
-        raise FontPartsError("The anchor could not be found.")
+        raise ValueError("The anchor could not be found.")
 
     def appendAnchor(self, name, position, color=None):
         """
@@ -1132,7 +1132,7 @@ class BaseGlyph(BaseObject, TransformationMixin, InterpolationMixin, SelectionMi
             index = self._getAnchorIndex(anchor)
         index = normalizers.normalizeAnchorIndex(index)
         if index >= self._len__anchors():
-            raise FontPartsError("No anchor located at index %d." % index)
+            raise ValueError("No anchor located at index %d." % index)
         self._removeAnchor(index)
 
     def _removeAnchor(self, index, **kwargs):
@@ -1200,7 +1200,7 @@ class BaseGlyph(BaseObject, TransformationMixin, InterpolationMixin, SelectionMi
     def _getitem__guidelines(self, index):
         index = normalizers.normalizeGuidelineIndex(index)
         if index >= self._len__guidelines():
-            raise FontPartsError("No guideline located at index %d." % index)
+            raise ValueError("No guideline located at index %d." % index)
         guideline = self._getGuideline(index)
         self._setGlyphInGuideline(guideline)
         return guideline
@@ -1219,7 +1219,7 @@ class BaseGlyph(BaseObject, TransformationMixin, InterpolationMixin, SelectionMi
         for i, other in enumerate(self.guidelines):
             if guideline == other:
                 return i
-        raise FontPartsError("The guideline could not be found.")
+        raise ValueError("The guideline could not be found.")
 
     def appendGuideline(self, position, angle, name=None, color=None):
         """
@@ -1271,7 +1271,7 @@ class BaseGlyph(BaseObject, TransformationMixin, InterpolationMixin, SelectionMi
             index = self._getGuidelineIndex(guideline)
         index = normalizers.normalizeGuidelineIndex(index)
         if index >= self._len__guidelines():
-            raise FontPartsError("No guideline located at index %d." % index)
+            raise ValueError("No guideline located at index %d." % index)
         self._removeGuideline(index)
 
     def _removeGuideline(self, index, **kwargs):
@@ -1402,7 +1402,8 @@ class BaseGlyph(BaseObject, TransformationMixin, InterpolationMixin, SelectionMi
             origin = (0, 0)
         origin = normalizers.normalizeCoordinateTuple(origin)
         if origin != (0, 0) and (width or height):
-            raise FontPartsError("The origin must not be set when scaling the width or height.")
+            raise FontPartsError(("The origin must not be set when "
+                                  "scaling the width or height."))
         super(BaseGlyph, self).scaleBy(value, origin=origin)
         sX, sY = value
         if width:
@@ -1600,9 +1601,9 @@ class BaseGlyph(BaseObject, TransformationMixin, InterpolationMixin, SelectionMi
         """
         factor = normalizers.normalizeInterpolationFactor(factor)
         if not isinstance(minGlyph, BaseGlyph):
-            raise FontPartsError("Interpolation to an instance of %r can not be performed from an instance of %r." % (self.__class__.__name__, minGlyph.__class__.__name__))
+            raise TypeError("Interpolation to an instance of %r can not be performed from an instance of %r." % (self.__class__.__name__, minGlyph.__class__.__name__))
         if not isinstance(maxGlyph, BaseGlyph):
-            raise FontPartsError("Interpolation to an instance of %r can not be performed from an instance of %r." % (self.__class__.__name__, maxGlyph.__class__.__name__))
+            raise TypeError("Interpolation to an instance of %r can not be performed from an instance of %r." % (self.__class__.__name__, maxGlyph.__class__.__name__))
         round = normalizers.normalizeBoolean(round)
         suppressError = normalizers.normalizeBoolean(suppressError)
         self._interpolate(factor, minGlyph, maxGlyph, round=round, suppressError=suppressError)
@@ -1618,7 +1619,8 @@ class BaseGlyph(BaseObject, TransformationMixin, InterpolationMixin, SelectionMi
         except IndexError:
             result = None
         if result is None and not suppressError:
-            raise FontPartsError("Glyphs '%s' and '%s' could not be interpolated." % (minGlyph.name, maxGlyph.name))
+            raise TypeError("Glyphs '%s' and '%s' could not be interpolated."
+                            % (minGlyph.name, maxGlyph.name))
         if result is not None:
             if round:
                 result = result.round()
@@ -1644,7 +1646,8 @@ class BaseGlyph(BaseObject, TransformationMixin, InterpolationMixin, SelectionMi
             False
             >>> compatible
             [Fatal] Glyph: "test1" + "test2"
-            [Fatal] Glyph: "test1" contains 1 contours | "test2" contains 2 contours
+            [Fatal] Glyph: "test1" contains 1 contours |
+                           "test2" contains 2 contours
             [Fatal] Contour: [0] + [0]
             [Fatal] Contour: [0] contains 4 segments | [0] contains 3 segments
 
@@ -1726,7 +1729,6 @@ class BaseGlyph(BaseObject, TransformationMixin, InterpolationMixin, SelectionMi
         if len(anchors2.difference(anchors1)) != 0:
             reporter.warning = True
             reporter.anchorsMissingFromGlyph1 = list(anchors2.difference(anchors1))
-
 
     # ------------
     # Data Queries
@@ -1819,14 +1821,14 @@ class BaseGlyph(BaseObject, TransformationMixin, InterpolationMixin, SelectionMi
         """
         name will be a string, but there may not be a
         layer with a name matching the string. If not,
-        a FontPartsError must be raised.
+        a ValueError must be raised.
 
         Subclasses may override this method.
         """
         for glyph in self.layers:
             if glyph.layer.name == name:
                 return glyph
-        raise FontPartsError("No layer named '%s' in glyph '%s'." % (name, self.name))
+        raise ValueError("No layer named '%s' in glyph '%s'." % (name, self.name))
 
     # new
 
@@ -1947,7 +1949,7 @@ class BaseGlyph(BaseObject, TransformationMixin, InterpolationMixin, SelectionMi
         transformation = (sx, 0, 0, sy, ox, oy)
         if path is not None:
             if not os.path.exists(path):
-                raise FontPartsError("No image located at '%s'." % path)
+                raise IOError("No image located at '%s'." % path)
             f = open(path, "rb")
             data = f.read()
             f.close()

--- a/Lib/fontParts/base/glyph.py
+++ b/Lib/fontParts/base/glyph.py
@@ -773,7 +773,7 @@ class BaseGlyph(BaseObject, TransformationMixin, InterpolationMixin, SelectionMi
         for i, other in enumerate(self.contours):
             if contour == other:
                 return i
-        raise ValueError("The contour could not be found.")
+        raise FontPartsError("The contour could not be found.")
 
     def appendContour(self, contour, offset=None):
         """
@@ -1083,7 +1083,7 @@ class BaseGlyph(BaseObject, TransformationMixin, InterpolationMixin, SelectionMi
         for i, other in enumerate(self.anchors):
             if anchor == other:
                 return i
-        raise ValueError("The anchor could not be found.")
+        raise FontPartsError("The anchor could not be found.")
 
     def appendAnchor(self, name, position, color=None):
         """
@@ -1219,7 +1219,7 @@ class BaseGlyph(BaseObject, TransformationMixin, InterpolationMixin, SelectionMi
         for i, other in enumerate(self.guidelines):
             if guideline == other:
                 return i
-        raise ValueError("The guideline could not be found.")
+        raise FontPartsError("The guideline could not be found.")
 
     def appendGuideline(self, position, angle, name=None, color=None):
         """
@@ -1619,8 +1619,9 @@ class BaseGlyph(BaseObject, TransformationMixin, InterpolationMixin, SelectionMi
         except IndexError:
             result = None
         if result is None and not suppressError:
-            raise TypeError("Glyphs '%s' and '%s' could not be interpolated."
-                            % (minGlyph.name, maxGlyph.name))
+            raise FontPartsError(("Glyphs '%s' and '%s' could not be "
+                                  "interpolated.")
+                                 % (minGlyph.name, maxGlyph.name))
         if result is not None:
             if round:
                 result = result.round()
@@ -1821,14 +1822,15 @@ class BaseGlyph(BaseObject, TransformationMixin, InterpolationMixin, SelectionMi
         """
         name will be a string, but there may not be a
         layer with a name matching the string. If not,
-        a ValueError must be raised.
+        a ``ValueError`` must be raised.
 
         Subclasses may override this method.
         """
         for glyph in self.layers:
             if glyph.layer.name == name:
                 return glyph
-        raise ValueError("No layer named '%s' in glyph '%s'." % (name, self.name))
+        raise ValueError("No layer named '%s' in glyph '%s'."
+                         % (name, self.name))
 
     # new
 
@@ -1881,7 +1883,6 @@ class BaseGlyph(BaseObject, TransformationMixin, InterpolationMixin, SelectionMi
         if not isinstance(layer, basestring):
             layer = layer.layer.name
         layerName = layer
-        glyphName = self.name
         layerName = normalizers.normalizeLayerName(layerName)
         found = False
         for glyph in self.layers:
@@ -1918,7 +1919,8 @@ class BaseGlyph(BaseObject, TransformationMixin, InterpolationMixin, SelectionMi
         """
         self.raiseNotImplementedError()
 
-    def addImage(self, path=None, data=None, scale=None, position=None, color=None):
+    def addImage(self, path=None, data=None, scale=None,
+                 position=None, color=None):
         """
         Set the image in the glyph.
 

--- a/Lib/fontParts/base/groups.py
+++ b/Lib/fontParts/base/groups.py
@@ -1,4 +1,3 @@
-from fontParts.base.errors import FontPartsError
 from fontParts.base.base import BaseDict, dynamicProperty, reference
 from fontParts.base import normalizers
 from fontParts.base.deprecated import DeprecatedGroups, RemovedGroups

--- a/Lib/fontParts/base/guideline.py
+++ b/Lib/fontParts/base/guideline.py
@@ -1,7 +1,6 @@
 import math
 
 from fontTools.misc import transform
-from fontParts.base.errors import FontPartsError
 from fontParts.base.base import (
     BaseObject, TransformationMixin, InterpolationMixin, SelectionMixin,
     dynamicProperty, PointPositionMixin, reference
@@ -12,8 +11,9 @@ from fontParts.base.color import Color
 from fontParts.base.deprecated import DeprecatedGuideline, RemovedGuideline
 
 
-class BaseGuideline(BaseObject, TransformationMixin, DeprecatedGuideline, 
-    RemovedGuideline, PointPositionMixin, InterpolationMixin, SelectionMixin):
+class BaseGuideline(BaseObject, TransformationMixin, DeprecatedGuideline,
+                    RemovedGuideline, PointPositionMixin, InterpolationMixin,
+                    SelectionMixin):
 
     """
     A guideline object. This object is almost always

--- a/Lib/fontParts/base/image.py
+++ b/Lib/fontParts/base/image.py
@@ -1,5 +1,4 @@
 from fontTools.misc import transform
-from fontParts.base.errors import FontPartsError
 from fontParts.base.base import (
     BaseObject, TransformationMixin, PointPositionMixin, SelectionMixin,
     dynamicProperty, reference

--- a/Lib/fontParts/base/info.py
+++ b/Lib/fontParts/base/info.py
@@ -1,15 +1,15 @@
-from ufoLib import fontInfoAttributesVersion3, validateFontInfoVersion3ValueForAttribute
-from fontParts.base.errors import FontPartsError
-from fontParts.base.base import BaseObject, dynamicProperty, interpolate, reference
+from ufoLib import (fontInfoAttributesVersion3,
+                    validateFontInfoVersion3ValueForAttribute)
+from fontParts.base.base import (BaseObject, dynamicProperty,
+                                 interpolate, reference)
 from fontParts.base import normalizers
 from fontParts.base.deprecated import DeprecatedInfo, RemovedInfo
 
 
-
 class BaseInfo(BaseObject, DeprecatedInfo, RemovedInfo):
-    from ufoLib import (fontInfoAttributesVersion3, 
-        validateFontInfoVersion3ValueForAttribute)
-    
+    from ufoLib import (fontInfoAttributesVersion3,
+                        validateFontInfoVersion3ValueForAttribute)
+
     copyAttributes = set(fontInfoAttributesVersion3)
     copyAttributes.remove("guidelines")
     copyAttributes = tuple(copyAttributes)
@@ -55,7 +55,8 @@ class BaseInfo(BaseObject, DeprecatedInfo, RemovedInfo):
     def _validateFontInfoAttributeValue(self, attr, value):
         valid = validateFontInfoVersion3ValueForAttribute(attr, value)
         if not valid:
-            raise FontPartsError("Invalid value %s for attribute '%s'." % (value, attr))
+            raise ValueError("Invalid value %s for attribute '%s'."
+                             % (value, attr))
         return value
 
     # ----------
@@ -250,9 +251,9 @@ class BaseInfo(BaseObject, DeprecatedInfo, RemovedInfo):
         """
         factor = normalizers.normalizeInterpolationFactor(factor)
         if not isinstance(minInfo, BaseInfo):
-            raise FontPartsError("Interpolation to an instance of %r can not be performed from an instance of %r." % (self.__class__.__name__, minInfo.__class__.__name__))
+            raise TypeError("Interpolation to an instance of %r can not be performed from an instance of %r." % (self.__class__.__name__, minInfo.__class__.__name__))
         if not isinstance(maxInfo, BaseInfo):
-            raise FontPartsError("Interpolation to an instance of %r can not be performed from an instance of %r." % (self.__class__.__name__, maxInfo.__class__.__name__))
+            raise TypeError("Interpolation to an instance of %r can not be performed from an instance of %r." % (self.__class__.__name__, maxInfo.__class__.__name__))
         round = normalizers.normalizeBoolean(round)
         suppressError = normalizers.normalizeBoolean(suppressError)
         self._interpolate(factor, minInfo, maxInfo, round=round, suppressError=suppressError)

--- a/Lib/fontParts/base/kerning.py
+++ b/Lib/fontParts/base/kerning.py
@@ -1,5 +1,5 @@
-from fontParts.base.errors import FontPartsError
-from fontParts.base.base import BaseDict, dynamicProperty, interpolate, reference
+from fontParts.base.base import (BaseDict, dynamicProperty, interpolate,
+                                 reference)
 from fontParts.base import normalizers
 from fontParts.base.deprecated import DeprecatedKerning, RemovedKerning
 
@@ -100,7 +100,7 @@ class BaseKerning(BaseDict, DeprecatedKerning, RemovedKerning):
         The default behavior is to round to increments of 1.
         """
         if not isinstance(multiple, int):
-            raise FontPartsError("The round multiple must be an int not %s." % multiple.__class__.__name__)
+            raise TypeError("The round multiple must be an int not %s." % multiple.__class__.__name__)
         self._round(multiple)
 
     def _round(self, multiple=1):
@@ -142,9 +142,9 @@ class BaseKerning(BaseDict, DeprecatedKerning, RemovedKerning):
         """
         factor = normalizers.normalizeInterpolationFactor(factor)
         if not isinstance(minKerning, BaseKerning):
-            raise FontPartsError("Interpolation to an instance of %r can not be performed from an instance of %r." % (self.__class__.__name__, minKerning.__class__.__name__))
+            raise TypeError("Interpolation to an instance of %r can not be performed from an instance of %r." % (self.__class__.__name__, minKerning.__class__.__name__))
         if not isinstance(maxKerning, BaseKerning):
-            raise FontPartsError("Interpolation to an instance of %r can not be performed from an instance of %r." % (self.__class__.__name__, maxKerning.__class__.__name__))
+            raise TypeError("Interpolation to an instance of %r can not be performed from an instance of %r." % (self.__class__.__name__, maxKerning.__class__.__name__))
         round = normalizers.normalizeBoolean(round)
         suppressError = normalizers.normalizeBoolean(suppressError)
         self._interpolate(factor, minKerning, maxKerning, round=round, suppressError=suppressError)

--- a/Lib/fontParts/base/layer.py
+++ b/Lib/fontParts/base/layer.py
@@ -1,4 +1,3 @@
-from fontParts.base.errors import FontPartsError
 from fontParts.base.base import (
     BaseObject, InterpolationMixin, SelectionMixin,
     dynamicProperty, reference
@@ -80,7 +79,7 @@ class _BaseGlyphVendor(BaseObject, SelectionMixin):
         """
         name = normalizers.normalizeGlyphName(name)
         if name not in self:
-            raise FontPartsError("No glyph named '%s'." % name)
+            raise ValueError("No glyph named '%s'." % name)
         glyph = self._getItem(name)
         self._setLayerInGlyph(glyph)
         return glyph
@@ -199,7 +198,7 @@ class _BaseGlyphVendor(BaseObject, SelectionMixin):
         """
         name = normalizers.normalizeGlyphName(name)
         if name not in self:
-            raise FontPartsError("No glyph with the name '%s' exists." % name)
+            raise ValueError("No glyph with the name '%s' exists." % name)
         self._removeGlyph(name)
 
     def _removeGlyph(self, name, **kwargs):
@@ -453,7 +452,8 @@ class BaseLayer(_BaseGlyphVendor, InterpolationMixin):
         value = normalizers.normalizeLayerName(value)
         existing = self.font.layerOrder
         if value in existing:
-            raise FontPartsError("A layer with the name '%s' already exists." % value)
+            raise ValueError("A layer with the name '%s' already exists."
+                             % value)
         self._set_name(value)
 
     def _get_name(self):
@@ -623,9 +623,9 @@ class BaseLayer(_BaseGlyphVendor, InterpolationMixin):
         """
         factor = normalizers.normalizeInterpolationFactor(factor)
         if not isinstance(minLayer, BaseLayer):
-            raise FontPartsError("Interpolation to an instance of %r can not be performed from an instance of %r." % (self.__class__.__name__, minLayer.__class__.__name__))
+            raise TypeError("Interpolation to an instance of %r can not be performed from an instance of %r." % (self.__class__.__name__, minLayer.__class__.__name__))
         if not isinstance(maxLayer, BaseLayer):
-            raise FontPartsError("Interpolation to an instance of %r can not be performed from an instance of %r." % (self.__class__.__name__, maxLayer.__class__.__name__))
+            raise TypeError("Interpolation to an instance of %r can not be performed from an instance of %r." % (self.__class__.__name__, maxLayer.__class__.__name__))
         round = normalizers.normalizeBoolean(round)
         suppressError = normalizers.normalizeBoolean(suppressError)
         self._interpolate(factor, minLayer, maxLayer, round=round, suppressError=suppressError)

--- a/Lib/fontParts/base/lib.py
+++ b/Lib/fontParts/base/lib.py
@@ -1,4 +1,3 @@
-from fontParts.base.errors import FontPartsError
 from fontParts.base.base import BaseDict, dynamicProperty, reference
 from fontParts.base import normalizers
 from fontParts.base.deprecated import DeprecatedLib, RemovedLib

--- a/Lib/fontParts/base/normalizers.py
+++ b/Lib/fontParts/base/normalizers.py
@@ -1,7 +1,6 @@
 # -*- coding: utf8 -*-
 
 from fontTools.misc.py23 import unicode, basestring, round3
-from fontParts.base.errors import FontPartsError
 
 # ----
 # Font
@@ -16,7 +15,7 @@ def normalizeFileFormatVersion(value):
     * Returned value will be a ``float``.
     """
     if not isinstance(value, (int, float)):
-        raise FontPartsError("File format versions must be instances of :ref:`type-int-float`, not %s." % type(value).__name__)
+        raise TypeError("File format versions must be instances of :ref:`type-int-float`, not %s." % type(value).__name__)
     return value
 
 
@@ -31,16 +30,16 @@ def normalizeLayerOrder(value, font):
       for each layer name.
     """
     if not isinstance(value, list):
-        raise FontPartsError("Layer order must be a list, not %s."
-                             % type(value).__name__)
+        raise TypeError("Layer order must be a list, not %s."
+                        % type(value).__name__)
     fontLayers = [layer.name for layer in font.layers]
     for name in value:
         if name not in fontLayers:
-            raise FontPartsError("Layer must exist in font. %s does not exist in font.layers." % name)
+            raise ValueError("Layer must exist in font. %s does not exist in font.layers." % name)
     from collections import Counter
     duplicates = [v for v, count in Counter(value).items() if count > 1]
     if len(duplicates) != 0:
-        raise FontPartsError("Duplicate layers are not allowed. Layer name(s) '%s' are duplicate(s)." % ", ".join(duplicates))
+        raise ValueError("Duplicate layers are not allowed. Layer name(s) '%s' are duplicate(s)." % ", ".join(duplicates))
     return [unicode(v) for v in value]
 
 
@@ -53,9 +52,9 @@ def normalizeDefaultLayer(value, font):
     * Returned value will be an unencoded ``unicode`` string.
     """
     if not isinstance(value, basestring):
-        raise FontPartsError("Layer names must be strings, not %s." % type(value).__name__)
+        raise TypeError("Layer names must be strings, not %s." % type(value).__name__)
     if value not in font.layerOrder:
-        raise FontPartsError("No layer with the name '%s' exists." % value)
+        raise ValueError("No layer with the name '%s' exists." % value)
     return unicode(value)
 
 
@@ -69,13 +68,13 @@ def normalizeGlyphOrder(value):
     * Returned value will be a ``list`` of unencoded ``unicode`` strings.
     """
     if not isinstance(value, list):
-        raise FontPartsError("Glyph order must be a list, not %s." % type(value).__name__)
+        raise TypeError("Glyph order must be a list, not %s." % type(value).__name__)
     for v in value:
         normalizeGlyphName(v)
     from collections import Counter
     duplicates = sorted(v for v, count in Counter(value).items() if count > 1)
     if len(duplicates) != 0:
-        raise FontPartsError("Duplicate glyph names are not allowed. Glyph name(s) '%s' are duplicate." % ", ".join(duplicates))
+        raise ValueError("Duplicate glyph names are not allowed. Glyph name(s) '%s' are duplicate." % ", ".join(duplicates))
     return [unicode(v) for v in value]
 
 
@@ -96,20 +95,20 @@ def normalizeKerningKey(value):
       ``unicode`` strings.
     """
     if not isinstance(value, (tuple, list)):
-        raise FontPartsError("Kerning key must be a tuple instance, not %s."
-                             % type(value).__name__)
+        raise TypeError("Kerning key must be a tuple instance, not %s."
+                        % type(value).__name__)
     if len(value) != 2:
-        raise FontPartsError("Kerning key must be a tuple containing two items, not %d." % len(value))
+        raise ValueError("Kerning key must be a tuple containing two items, not %d." % len(value))
     for v in value:
         if not isinstance(v, basestring):
-            raise FontPartsError("Kerning key items must be strings, not %s."
-                                 % type(v).__name__)
+            raise TypeError("Kerning key items must be strings, not %s."
+                            % type(v).__name__)
         if len(v) < 1:
-            raise FontPartsError("Kerning key items must be one character long")
+            raise ValueError("Kerning key items must be one character long")
     if value[0].startswith("public.") and not value[0].startswith("public.kern1."):
-        raise FontPartsError("Left Kerning key group must start with public.kern1.")
+        raise ValueError("Left Kerning key group must start with public.kern1.")
     if value[1].startswith("public.") and not value[1].startswith("public.kern2."):
-        raise FontPartsError("Right Kerning key group must start with public.kern2.")
+        raise ValueError("Right Kerning key group must start with public.kern2.")
     return tuple([unicode(v) for v in value])
 
 
@@ -121,7 +120,7 @@ def normalizeKerningValue(value):
     * Returned value is the same type as input value.
     """
     if not isinstance(value, (int, float)):
-        raise FontPartsError("Kerning value must be a int or a float, not %s." % type(value).__name__)
+        raise TypeError("Kerning value must be a int or a float, not %s." % type(value).__name__)
     return value
 
 
@@ -138,9 +137,9 @@ def normalizeGroupKey(value):
     * Returned value will be an unencoded ``unicode`` string.
     """
     if not isinstance(value, basestring):
-        raise FontPartsError("Group key must be a string, not %s." % type(value).__name__)
+        raise TypeError("Group key must be a string, not %s." % type(value).__name__)
     if len(value) < 1:
-        raise FontPartsError("Group key must be at least one character long.")
+        raise ValueError("Group key must be at least one character long.")
     return unicode(value)
 
 
@@ -153,7 +152,7 @@ def normalizeGroupValue(value):
     * Returned value will be a ``list`` of unencoded ``unicode`` strings.
     """
     if not isinstance(value, list):
-        raise FontPartsError("Group value must be a list, not %s." % type(value).__name__)
+        raise TypeError("Group value must be a list, not %s." % type(value).__name__)
     for v in value:
         normalizeGlyphName(v)
     return [unicode(v) for v in value]
@@ -171,7 +170,7 @@ def normalizeFeatureText(value):
     * Returned value will be an unencoded ``unicode`` string.
     """
     if not isinstance(value, basestring):
-        raise FontPartsError("Feature text must be a string, not %s." % type(value).__name__)
+        raise TypeError("Feature text must be a string, not %s." % type(value).__name__)
     return unicode(value)
 
 
@@ -188,9 +187,9 @@ def normalizeLibKey(value):
     * Returned value will be an unencoded ``unicode`` string.
     """
     if not isinstance(value, basestring):
-        raise FontPartsError("Lib key must be a string, not %s." % type(value).__name__)
+        raise TypeError("Lib key must be a string, not %s." % type(value).__name__)
     if len(value) < 1:
-        raise FontPartsError("Lib key must be at least one character.")
+        raise ValueError("Lib key must be at least one character.")
     return unicode(value)
 
 
@@ -202,7 +201,7 @@ def normalizeLibValue(value):
     * Returned value is the same type as the input value.
     """
     if value is None:
-        raise FontPartsError("Lib value must not be None.")
+        raise ValueError("Lib value must not be None.")
     if isinstance(value, (list, tuple)):
         for v in value:
             normalizeLibValue(v)
@@ -237,9 +236,9 @@ def normalizeLayerName(value):
     * Returned value will be an unencoded ``unicode`` string.
     """
     if not isinstance(value, basestring):
-        raise FontPartsError("Layer names must be strings, not %s." % type(value).__name__)
+        raise TypeError("Layer names must be strings, not %s." % type(value).__name__)
     if len(value) < 1:
-        raise FontPartsError("Layer names must be at least one character long.")
+        raise ValueError("Layer names must be at least one character long.")
     return unicode(value)
 
 
@@ -267,9 +266,9 @@ def normalizeGlyphName(value):
     * Returned value will be an unencoded ``unicode`` string.
     """
     if not isinstance(value, basestring):
-        raise FontPartsError("Glyph names must be strings, not %s." % type(value).__name__)
+        raise TypeError("Glyph names must be strings, not %s." % type(value).__name__)
     if len(value) < 1:
-        raise FontPartsError("Glyph names must be at least one character long.")
+        raise ValueError("Glyph names must be at least one character long.")
     return unicode(value)
 
 
@@ -282,7 +281,7 @@ def normalizeGlyphUnicodes(value):
     * Returned value will be a ``list`` of ints.
     """
     if not isinstance(value, list):
-        raise FontPartsError("Glyph unicodes must be a list, not %s." % type(value).__name__)
+        raise TypeError("Glyph unicodes must be a list, not %s." % type(value).__name__)
     return [normalizeGlyphUnicode(v) for v in value]
 
 
@@ -295,14 +294,14 @@ def normalizeGlyphUnicode(value):
     * Returned value will be an ``int``.
     """
     if not isinstance(value, (int, basestring)):
-        raise FontPartsError("Glyph unicode must be a int or hex string, not %s." % type(value).__name__)
+        raise TypeError("Glyph unicode must be a int or hex string, not %s." % type(value).__name__)
     if isinstance(value, basestring):
         try:
             value = int(value, 16)
         except ValueError:
-            raise FontPartsError("Glyph unicode hex must be a valid hex string.")
+            raise ValueError("Glyph unicode hex must be a valid hex string.")
     if value < 0 or value > 1114111:
-        raise FontPartsError("Glyph unicode must be in the Unicode range.")
+        raise ValueError("Glyph unicode must be in the Unicode range.")
     return value
 
 
@@ -314,7 +313,7 @@ def normalizeGlyphWidth(value):
     * Returned value is the same type as the input value.
     """
     if not isinstance(value, (int, float)):
-        raise FontPartsError("Glyph width must be an :ref:`type-int-float`, not %s." % type(value).__name__)
+        raise TypeError("Glyph width must be an :ref:`type-int-float`, not %s." % type(value).__name__)
     return value
 
 
@@ -326,7 +325,7 @@ def normalizeGlyphLeftMargin(value):
     * Returned value is the same type as the input value.
     """
     if not isinstance(value, (int, float)):
-        raise FontPartsError("Glyph left margin must be an :ref:`type-int-float`, not %s." % type(value).__name__)
+        raise TypeError("Glyph left margin must be an :ref:`type-int-float`, not %s." % type(value).__name__)
     return value
 
 
@@ -338,7 +337,7 @@ def normalizeGlyphRightMargin(value):
     * Returned value is the same type as the input value.
     """
     if not isinstance(value, (int, float)):
-        raise FontPartsError("Glyph right margin must be an :ref:`type-int-float`, not %s." % type(value).__name__)
+        raise TypeError("Glyph right margin must be an :ref:`type-int-float`, not %s." % type(value).__name__)
     return value
 
 
@@ -350,7 +349,7 @@ def normalizeGlyphHeight(value):
     * Returned value is the same type as the input value.
     """
     if not isinstance(value, (int, float)):
-        raise FontPartsError("Glyph height must be an :ref:`type-int-float`, not %s." % type(value).__name__)
+        raise TypeError("Glyph height must be an :ref:`type-int-float`, not %s." % type(value).__name__)
     return value
 
 
@@ -362,7 +361,7 @@ def normalizeGlyphBottomMargin(value):
     * Returned value is the same type as the input value.
     """
     if not isinstance(value, (int, float)):
-        raise FontPartsError("Glyph bottom margin must be an :ref:`type-int-float`, not %s." % type(value).__name__)
+        raise TypeError("Glyph bottom margin must be an :ref:`type-int-float`, not %s." % type(value).__name__)
     return value
 
 
@@ -374,7 +373,7 @@ def normalizeGlyphTopMargin(value):
     * Returned value is the same type as the input value.
     """
     if not isinstance(value, (int, float)):
-        raise FontPartsError("Glyph top margin must be an :ref:`type-int-float`, not %s." % type(value).__name__)
+        raise TypeError("Glyph top margin must be an :ref:`type-int-float`, not %s." % type(value).__name__)
     return value
 
 def normalizeGlyphFormatVersion(value):
@@ -385,10 +384,10 @@ def normalizeGlyphFormatVersion(value):
     * Returned value will be an int.
     """
     if not isinstance(value, (int, float)):
-        raise FontPartsError("Glyph Format Version must be an :ref:`type-int-float`, not %s." % type(value).__name__)
+        raise TypeError("Glyph Format Version must be an :ref:`type-int-float`, not %s." % type(value).__name__)
     value = int(value)
     if value not in (1, 2):
-        raise FontPartsError("Glyph Format Version must be either 1 or 2, not %s." % value)
+        raise ValueError("Glyph Format Version must be either 1 or 2, not %s." % value)
     return value
 
 # -------
@@ -443,9 +442,9 @@ def normalizePointType(value):
     """
     allowedTypes = ['move', 'line', 'offcurve', 'curve', 'qcurve']
     if not isinstance(value, basestring):
-        raise FontPartsError("Point type must be a string, not %s." % type(value).__name__)
+        raise TypeError("Point type must be a string, not %s." % type(value).__name__)
     if value not in allowedTypes:
-        raise FontPartsError("Point type must be '%s'; not %r." % ("', '".join(allowedTypes), value))
+        raise ValueError("Point type must be '%s'; not %r." % ("', '".join(allowedTypes), value))
     return unicode(value)
 
 
@@ -458,9 +457,9 @@ def normalizePointName(value):
     * Returned value will be an unencoded ``unicode`` string.
     """
     if not isinstance(value, basestring):
-        raise FontPartsError("Point names must be strings, not %s." % type(value).__name__)
+        raise TypeError("Point names must be strings, not %s." % type(value).__name__)
     if len(value) < 1:
-        raise FontPartsError("Point names must be at least one character long.")
+        raise ValueError("Point names must be at least one character long.")
     return unicode(value)
 
 
@@ -509,9 +508,9 @@ def normalizeSegmentType(value):
     """
     allowedTypes = ['move', 'line', 'curve', 'qcurve']
     if not isinstance(value, basestring):
-        raise FontPartsError("Segment type must be a string, not %s." % type(value).__name__)
+        raise TypeError("Segment type must be a string, not %s." % type(value).__name__)
     if value not in allowedTypes:
-        raise FontPartsError("Segment type must be '%s'; not %r." % ("', '".join(allowedTypes), value))
+        raise ValueError("Segment type must be '%s'; not %r." % ("', '".join(allowedTypes), value))
     return unicode(value)
 
 
@@ -546,9 +545,9 @@ def normalizeBPointType(value):
     """
     allowedTypes = ['corner', 'curve']
     if not isinstance(value, basestring):
-        raise FontPartsError("bPoint type must be a string, not %s." % type(value).__name__)
+        raise TypeError("bPoint type must be a string, not %s." % type(value).__name__)
     if value not in allowedTypes:
-        raise FontPartsError("bPoint type must be 'corner' or 'curve', not %r." % value)
+        raise ValueError("bPoint type must be 'corner' or 'curve', not %r." % value)
     return unicode(value)
 
 
@@ -611,9 +610,9 @@ def normalizeAnchorName(value):
     * Returned value will be an unencoded ``unicode`` string.
     """
     if not isinstance(value, basestring):
-        raise FontPartsError("Anchor names must be strings, not %s." % type(value).__name__)
+        raise TypeError("Anchor names must be strings, not %s." % type(value).__name__)
     if len(value) < 1:
-        raise FontPartsError("Anchor names must be at least one character long.")
+        raise ValueError("Anchor names must be at least one character long.")
     return unicode(value)
 
 
@@ -652,9 +651,9 @@ def normalizeGuidelineAngle(value):
     * Returned value is a ``float`` between 0 and 360.
     """
     if not isinstance(value, (int, float)):
-        raise FontPartsError("Guideline angle must be instances of :ref:`type-int-float`, not %s." % type(value).__name__)
+        raise TypeError("Guideline angle must be instances of :ref:`type-int-float`, not %s." % type(value).__name__)
     if abs(value) > 360:
-        raise FontPartsError("Guideline angle must be between -360 and 360.")
+        raise ValueError("Guideline angle must be between -360 and 360.")
     if value < 0:
         value = value + 360
     return float(value)
@@ -669,9 +668,9 @@ def normalizeGuidelineName(value):
     * Returned value will be an unencoded ``unicode`` string.
     """
     if not isinstance(value, basestring):
-        raise FontPartsError("Guideline names must be strings, not %s." % type(value).__name__)
+        raise TypeError("Guideline names must be strings, not %s." % type(value).__name__)
     if len(value) < 1:
-        raise FontPartsError("Guideline names must be at least one character long.")
+        raise ValueError("Guideline names must be at least one character long.")
     return unicode(value)
 
 
@@ -687,7 +686,8 @@ def normalizeInternalObjectType(value, cls, name):
     * Returned value is the same type as the input value.
     """
     if not isinstance(value, cls):
-        raise FontPartsError("%s must be a %s instance, not %s." % (name, name, type(value).__name__))
+        raise TypeError("%s must be a %s instance, not %s."
+                        % (name, name, type(value).__name__))
     return value
 
 
@@ -701,7 +701,8 @@ def normalizeBoolean(value):
     if isinstance(value, int):
         value = bool(value)
     if not isinstance(value, bool):
-        raise FontPartsError("Boolean values must be True or False, not '%s'." % value)
+        raise ValueError("Boolean values must be True or False, not '%s'."
+                         % value)
     return value
 
 
@@ -716,7 +717,8 @@ def normalizeIndex(value):
     """
     if value is not None:
         if not isinstance(value, int):
-            raise FontPartsError("Indexes must be None or integers, not %s." % type(value).__name__)
+            raise TypeError("Indexes must be None or integers, not %s."
+                            % type(value).__name__)
     return value
 
 
@@ -732,13 +734,14 @@ def normalizeIdentifier(value):
     if value is None:
         return value
     if not isinstance(value, basestring):
-        raise FontPartsError("Identifiers must be strings, not %s." % type(value).__name__)
+        raise TypeError("Identifiers must be strings, not %s."
+                        % type(value).__name__)
     if len(value) > 100:
-        raise FontPartsError("The identifier string has a length (%d) greater than the maximum allowed (100)." % len(value))
+        raise ValueError("The identifier string has a length (%d) greater than the maximum allowed (100)." % len(value))
     for c in value:
         v = ord(c)
         if v < 0x20 or v > 0x7E:
-            raise FontPartsError("The identifier string ('%s') contains a character out size of the range 0x20 - 0x7E." % value)
+            raise ValueError("The identifier string ('%s') contains a character out size of the range 0x20 - 0x7E." % value)
     return unicode(value)
 
 
@@ -752,7 +755,7 @@ def normalizeX(value):
     * Returned value is the same type as the input value.
     """
     if not isinstance(value, (int, float)):
-        raise FontPartsError("X coordinates must be instances of :ref:`type-int-float`, not %s." % type(value).__name__)
+        raise TypeError("X coordinates must be instances of :ref:`type-int-float`, not %s." % type(value).__name__)
     return value
 
 
@@ -764,7 +767,7 @@ def normalizeY(value):
     * Returned value is the same type as the input value.
     """
     if not isinstance(value, (int, float)):
-        raise FontPartsError("Y coordinates must be instances of :ref:`type-int-float`, not %s." % type(value).__name__)
+        raise TypeError("Y coordinates must be instances of :ref:`type-int-float`, not %s." % type(value).__name__)
     return value
 
 
@@ -779,9 +782,9 @@ def normalizeCoordinateTuple(value):
       the input values.
     """
     if not isinstance(value, (tuple, list)):
-        raise FontPartsError("Coordinates must be tuple instances, not %s." % type(value).__name__)
+        raise TypeError("Coordinates must be tuple instances, not %s." % type(value).__name__)
     if len(value) != 2:
-        raise FontPartsError("Coordinates must be tuples containing two items, not %d." % len(value))
+        raise ValueError("Coordinates must be tuples containing two items, not %d." % len(value))
     x, y = value
     x = normalizeX(x)
     y = normalizeY(y)
@@ -799,16 +802,16 @@ def normalizeBoundingBox(value):
     * Returned value will be a tuple of four ``float``.
     """
     if not isinstance(value, (tuple, list)):
-        raise FontPartsError("Bounding box be tuple instances, not %s." % type(value).__name__)
+        raise TypeError("Bounding box be tuple instances, not %s." % type(value).__name__)
     if len(value) != 4:
-        raise FontPartsError("Bounding box be tuples containing four items, not %d." % len(value))
+        raise ValueError("Bounding box be tuples containing four items, not %d." % len(value))
     for v in value:
         if not isinstance(v, (int, float)):
-            raise FontPartsError("Bounding box values must be instances of :ref:`type-int-float`, not %s." % type(value).__name__)
+            raise TypeError("Bounding box values must be instances of :ref:`type-int-float`, not %s." % type(value).__name__)
     if value[0] > value[2]:
-        raise FontPartsError("Bounding box xMin must be less than or equal to xMax.")
+        raise ValueError("Bounding box xMin must be less than or equal to xMax.")
     if value[1] > value[3]:
-        raise FontPartsError("Bounding box yMin must be less than or equal to yMax.")
+        raise ValueError("Bounding box yMin must be less than or equal to yMax.")
     return tuple([float(v) for v in value])
 
 
@@ -825,12 +828,14 @@ def normalizeColor(value):
     """
     from fontParts.base.color import Color
     if not isinstance(value, (tuple, list, Color)):
-        raise FontPartsError("Colors must be tuple instances, not %s." % type(value).__name__)
+        raise TypeError("Colors must be tuple instances, not %s."
+                        % type(value).__name__)
     if not len(value) == 4:
-        raise FontPartsError("Colors must contain four values, not %d." % len(value))
+        raise ValueError("Colors must contain four values, not %d."
+                         % len(value))
     for component, v in zip("rgba", value):
         if v < 0 or v > 1:
-            raise FontPartsError("The value for the %s component (%s) is not between 0 and 1." % (component, v))
+            raise ValueError("The value for the %s component (%s) is not between 0 and 1." % (component, v))
     return tuple(value)
 
 
@@ -844,7 +849,7 @@ def normalizeGlyphNote(value):
     * Returned value is an unencoded ``unicode`` string
     """
     if not isinstance(value, basestring):
-        raise FontPartsError("Note must be a string, not %s." % type(value).__name__)
+        raise TypeError("Note must be a string, not %s." % type(value).__name__)
     return unicode(value)
 
 
@@ -858,7 +863,7 @@ def normalizeFilePath(value):
     * Returned value is the same type as the input value.
     """
     if not isinstance(value, basestring):
-        raise FontPartsError("File paths must be strings, not %s." % type(value).__name__)
+        raise TypeError("File paths must be strings, not %s." % type(value).__name__)
     return value
 
 
@@ -874,15 +879,15 @@ def normalizeInterpolationFactor(value):
     * Returned value is a ``tuple`` of two ``float``.
     """
     if not isinstance(value, (int, float, list, tuple)):
-        raise FontPartsError("Interpolation factor must be an int, float, or tuple instances, not %s." % type(value).__name__)
+        raise TypeError("Interpolation factor must be an int, float, or tuple instances, not %s." % type(value).__name__)
     if isinstance(value, (int, float)):
         value = (float(value), float(value))
     elif isinstance(value, (list, tuple)):
         if not len(value) == 2:
-            raise FontPartsError("Interpolation factor tuple must contain two values, not %d." % len(value))
+            raise ValueError("Interpolation factor tuple must contain two values, not %d." % len(value))
         for v in value:
             if not isinstance(v, (int, float)):
-                raise FontPartsError("Interpolation factor tuple values must be an :ref:`type-int-float`, not %s." % type(value).__name__)
+                raise TypeError("Interpolation factor tuple values must be an :ref:`type-int-float`, not %s." % type(value).__name__)
         value = tuple([float(v) for v in value])
     return value
 
@@ -901,12 +906,12 @@ def normalizeTransformationMatrix(value):
     * Returned value is a ``tuple`` of six ``float``.
     """
     if not isinstance(value, (tuple, list)):
-        raise FontPartsError("Transformation matrices must be tuple instances, not %s." % type(value).__name__)
+        raise TypeError("Transformation matrices must be tuple instances, not %s." % type(value).__name__)
     if not len(value) == 6:
-        raise FontPartsError("Transformation matrices must contain six values, not %d." % len(value))
+        raise ValueError("Transformation matrices must contain six values, not %d." % len(value))
     for v in value:
         if not isinstance(v, (int, float)):
-            raise FontPartsError("Transformation matrix values must be instances of :ref:`type-int-float`, not %s." % type(value).__name__)
+            raise TypeError("Transformation matrix values must be instances of :ref:`type-int-float`, not %s." % type(value).__name__)
     return tuple([float(v) for v in value])
 
 
@@ -932,9 +937,9 @@ def normalizeTransformationRotationAngle(value):
     * Returned value is a `float` between 0 and 360.
     """
     if not isinstance(value, (int, float)):
-        raise FontPartsError("Angles must be instances of :ref:`type-int-float`, not %s." % type(value).__name__)
+        raise TypeError("Angles must be instances of :ref:`type-int-float`, not %s." % type(value).__name__)
     if abs(value) > 360:
-        raise FontPartsError("The value for the angle (%s) is not between -360 and 360." % value)
+        raise ValueError("The value for the angle (%s) is not between -360 and 360." % value)
     if value < 0:
         value = value + 360
     return float(value)
@@ -952,19 +957,19 @@ def normalizeTransformationSkewAngle(value):
     * Returned value is a ``tuple`` of two ``float`` between 0 and 360.
     """
     if not isinstance(value, (int, float, list, tuple)):
-        raise FontPartsError("Transformation skew angle must be an int, float, or tuple instances, not %s." % type(value).__name__)
+        raise TypeError("Transformation skew angle must be an int, float, or tuple instances, not %s." % type(value).__name__)
     if isinstance(value, (int, float)):
         value = (float(value), 0)
     elif isinstance(value, (list, tuple)):
         if not len(value) == 2:
-            raise FontPartsError("Transformation skew angle tuple must contain two values, not %d." % len(value))
+            raise ValueError("Transformation skew angle tuple must contain two values, not %d." % len(value))
         for v in value:
             if not isinstance(v, (int, float)):
-                raise FontPartsError("Transformation skew angle tuple values must be an :ref:`type-int-float`, not %s." % type(value).__name__)
+                raise TypeError("Transformation skew angle tuple values must be an :ref:`type-int-float`, not %s." % type(value).__name__)
         value = tuple([float(v) for v in value])
     for v in value:
         if abs(v) > 360:
-            raise FontPartsError("Transformation skew angle must be between -360 and 360.")
+            raise ValueError("Transformation skew angle must be between -360 and 360.")
     return tuple([v + 360 if v < 0 else v for v in value])
 
 
@@ -978,15 +983,15 @@ def normalizeTransformationScale(value):
     * Returned value is a ``tuple`` of two ``float``\s.
     """
     if not isinstance(value, (int, float, list, tuple)):
-        raise FontPartsError("Transformation scale must be an int, float, or tuple instances, not %s." % type(value).__name__)
+        raise TypeError("Transformation scale must be an int, float, or tuple instances, not %s." % type(value).__name__)
     if isinstance(value, (int, float)):
         value = (float(value), float(value))
     elif isinstance(value, (list, tuple)):
         if not len(value) == 2:
-            raise FontPartsError("Transformation scale tuple must contain two values, not %d." % len(value))
+            raise ValueError("Transformation scale tuple must contain two values, not %d." % len(value))
         for v in value:
             if not isinstance(v, (int, float)):
-                raise FontPartsError("Transformation scale tuple values must be an :ref:`type-int-float`, not %s." % type(value).__name__)
+                raise TypeError("Transformation scale tuple values must be an :ref:`type-int-float`, not %s." % type(value).__name__)
         value = tuple([float(v) for v in value])
     return value
 
@@ -1004,6 +1009,6 @@ def normalizeRounding(value):
 
     """
     if not isinstance(value, (int, float)):
-        raise FontPartsError("Value to round must be an int or float, not %s."
+        raise TypeError("Value to round must be an int or float, not %s."
                              % type(value).__name__)
     return round3(value)

--- a/Lib/fontParts/base/point.py
+++ b/Lib/fontParts/base/point.py
@@ -4,7 +4,6 @@ from fontParts.base.base import (
     dynamicProperty, reference
 )
 from fontParts.base import normalizers
-from fontParts.base.errors import FontPartsError
 from fontParts.base.deprecated import DeprecatedPoint, RemovedPoint
 
 

--- a/Lib/fontParts/test/test_anchor.py
+++ b/Lib/fontParts/test/test_anchor.py
@@ -37,7 +37,7 @@ class TestAnchor(unittest.TestCase):
 
     def test_set_invalid(self):
         anchor = self.getAnchor_generic()
-        with self.assertRaises(FontPartsError):
+        with self.assertRaises(TypeError):
             anchor.name = 123
 
     # Color
@@ -68,27 +68,27 @@ class TestAnchor(unittest.TestCase):
 
     def test_color_set_invalid_over_max(self):
         anchor = self.getAnchor_generic()
-        with self.assertRaises(FontPartsError):
+        with self.assertRaises(ValueError):
             anchor.color = (1.1, 0.2, 0.3, 0.4)
 
     def test_color_set_invalid_uner_min(self):
         anchor = self.getAnchor_generic()
-        with self.assertRaises(FontPartsError):
+        with self.assertRaises(ValueError):
             anchor.color = (-0.1, 0.2, 0.3, 0.4)
 
     def test_color_set_invalid_too_few(self):
         anchor = self.getAnchor_generic()
-        with self.assertRaises(FontPartsError):
+        with self.assertRaises(ValueError):
             anchor.color = (0.1, 0.2, 0.3)
 
     def test_color_set_invalid_string(self):
         anchor = self.getAnchor_generic()
-        with self.assertRaises(FontPartsError):
+        with self.assertRaises(TypeError):
             anchor.color = "0.1,0.2,0.3,0.4"
 
     def test_color_set_invalid_int(self):
         anchor = self.getAnchor_generic()
-        with self.assertRaises(FontPartsError):
+        with self.assertRaises(TypeError):
             anchor.color = 123
 
     # Identifier
@@ -160,12 +160,12 @@ class TestAnchor(unittest.TestCase):
 
     def test_x_set_invalid_none(self):
         anchor = self.getAnchor_generic()
-        with self.assertRaises(FontPartsError):
+        with self.assertRaises(TypeError):
             anchor.x = None
 
     def test_x_set_valid_string(self):
         anchor = self.getAnchor_generic()
-        with self.assertRaises(FontPartsError):
+        with self.assertRaises(TypeError):
             anchor.x = "ABC"
 
     # y
@@ -201,12 +201,12 @@ class TestAnchor(unittest.TestCase):
 
     def test_y_set_invalid_none(self):
         anchor = self.getAnchor_generic()
-        with self.assertRaises(FontPartsError):
+        with self.assertRaises(TypeError):
             anchor.y = None
 
     def test_y_set_valid_string(self):
         anchor = self.getAnchor_generic()
-        with self.assertRaises(FontPartsError):
+        with self.assertRaises(TypeError):
             anchor.y = "ABC"
 
     # -------
@@ -273,17 +273,17 @@ class TestAnchor(unittest.TestCase):
 
     def test_transformBy_invalid_one_string_value(self):
         anchor = self.getAnchor_generic()
-        with self.assertRaises(FontPartsError):
+        with self.assertRaises(TypeError):
             anchor.transformBy((1, 0, 0, 1, 0, "0"))
 
     def test_transformBy_invalid_all_string_values(self):
         anchor = self.getAnchor_generic()
-        with self.assertRaises(FontPartsError):
+        with self.assertRaises(TypeError):
             anchor.transformBy("1, 0, 0, 1, 0, 0")
 
     def test_transformBy_invalid_int_value(self):
         anchor = self.getAnchor_generic()
-        with self.assertRaises(FontPartsError):
+        with self.assertRaises(TypeError):
             anchor.transformBy(123)
 
     # moveBy
@@ -296,17 +296,17 @@ class TestAnchor(unittest.TestCase):
 
     def test_moveBy_invalid_one_string_value(self):
         anchor = self.getAnchor_generic()
-        with self.assertRaises(FontPartsError):
+        with self.assertRaises(TypeError):
             anchor.moveBy((-1, "2"))
 
     def test_moveBy_invalid_all_strings_value(self):
         anchor = self.getAnchor_generic()
-        with self.assertRaises(FontPartsError):
+        with self.assertRaises(TypeError):
             anchor.moveBy("-1, 2")
 
     def test_moveBy_invalid_int_value(self):
         anchor = self.getAnchor_generic()
-        with self.assertRaises(FontPartsError):
+        with self.assertRaises(TypeError):
             anchor.moveBy(1)
 
     # scaleBy
@@ -331,17 +331,17 @@ class TestAnchor(unittest.TestCase):
 
     def test_scaleBy_invalid_one_string_value(self):
         anchor = self.getAnchor_generic()
-        with self.assertRaises(FontPartsError):
+        with self.assertRaises(TypeError):
             anchor.scaleBy((-1, "2"))
 
     def test_scaleBy_invalid_two_string_values(self):
         anchor = self.getAnchor_generic()
-        with self.assertRaises(FontPartsError):
+        with self.assertRaises(TypeError):
             anchor.scaleBy("-1, 2")
 
     def test_scaleBy_invalid_tuple_too_many_values(self):
         anchor = self.getAnchor_generic()
-        with self.assertRaises(FontPartsError):
+        with self.assertRaises(ValueError):
             anchor.scaleBy((-1, 2, -3))
 
     # rotateBy
@@ -360,17 +360,17 @@ class TestAnchor(unittest.TestCase):
 
     def test_rotateBy_invalid_string_value(self):
         anchor = self.getAnchor_generic()
-        with self.assertRaises(FontPartsError):
+        with self.assertRaises(TypeError):
             anchor.rotateBy("45")
 
     def test_rotateBy_invalid_too_large_value_positive(self):
         anchor = self.getAnchor_generic()
-        with self.assertRaises(FontPartsError):
+        with self.assertRaises(ValueError):
             anchor.rotateBy(361)
 
     def test_rotateBy_invalid_too_large_value_negative(self):
         anchor = self.getAnchor_generic()
-        with self.assertRaises(FontPartsError):
+        with self.assertRaises(ValueError):
             anchor.rotateBy(-361)
 
     # skewBy

--- a/Lib/fontParts/test/test_bPoint.py
+++ b/Lib/fontParts/test/test_bPoint.py
@@ -1,6 +1,5 @@
 import unittest
 import collections
-from fontParts.base import FontPartsError
 
 
 class TestBPoint(unittest.TestCase):

--- a/Lib/fontParts/test/test_component.py
+++ b/Lib/fontParts/test/test_component.py
@@ -33,17 +33,17 @@ class TestComponent(unittest.TestCase):
 
     def test_baseGlyph_invalid_set_none(self):
         component = self.getComponent_generic()
-        with self.assertRaises(FontPartsError):
+        with self.assertRaises(TypeError):
             component.baseGlyph = None
 
     def test_baseGlyph_invalid_set_empty_string(self):
         component = self.getComponent_generic()
-        with self.assertRaises(FontPartsError):
+        with self.assertRaises(ValueError):
             component.baseGlyph = ""
 
     def test_baseGlyph_invalid_set_int(self):
         component = self.getComponent_generic()
-        with self.assertRaises(FontPartsError):
+        with self.assertRaises(TypeError):
             component.baseGlyph = 123
 
     # ------

--- a/Lib/fontParts/test/test_contour.py
+++ b/Lib/fontParts/test/test_contour.py
@@ -227,7 +227,6 @@ class TestContour(unittest.TestCase):
     def test_selectedPoints_setEmptyList(self):
         contour = self.getContour_bounds()
         point1 = contour.points[0]
-        point2 = contour.points[1]
         try:
             point1.selected = True
         except NotImplementedError:
@@ -251,7 +250,7 @@ class TestContour(unittest.TestCase):
         )
 
     def test_selectedBPoints_setSubObject(self):
-        contour= self.getContour_bounds()
+        contour = self.getContour_bounds()
         bPoint1 = contour.bPoints[0]
         bPoint2 = contour.bPoints[1]
         try:
@@ -281,7 +280,6 @@ class TestContour(unittest.TestCase):
     def test_selectedBPoints_setEmptyList(self):
         contour = self.getContour_bounds()
         bPoint1 = contour.bPoints[0]
-        bPoint2 = contour.bPoints[1]
         try:
             bPoint1.selected = True
         except NotImplementedError:

--- a/Lib/fontParts/test/test_features.py
+++ b/Lib/fontParts/test/test_features.py
@@ -1,6 +1,5 @@
 import unittest
 import collections
-from fontParts.base import FontPartsError
 
 
 class TestFeatures(unittest.TestCase):
@@ -36,7 +35,7 @@ class TestFeatures(unittest.TestCase):
 
     def test_text_invalid_set(self):
         features = self.getFeatures_generic()
-        with self.assertRaises(FontPartsError):
+        with self.assertRaises(TypeError):
             features.text = 123
 
     # ----

--- a/Lib/fontParts/test/test_font.py
+++ b/Lib/fontParts/test/test_font.py
@@ -1,6 +1,5 @@
 import unittest
 import collections
-from fontParts.base import FontPartsError
 
 
 class TestFont(unittest.TestCase):
@@ -17,7 +16,7 @@ class TestFont(unittest.TestCase):
 
     def test_getLayer_unknown(self):
         font = self.getFont_layers()
-        with self.assertRaises(FontPartsError):
+        with self.assertRaises(ValueError):
             font.getLayer("There is no layer with this name.")
 
     # ------

--- a/Lib/fontParts/test/test_glyph.py
+++ b/Lib/fontParts/test/test_glyph.py
@@ -1,6 +1,5 @@
 import unittest
 import collections
-from fontParts.base import FontPartsError
 
 
 class TestGlyph(unittest.TestCase):
@@ -74,12 +73,12 @@ class TestGlyph(unittest.TestCase):
 
     def test_width_set_invalid_string(self):
         glyph = self.getGlyph_generic()
-        with self.assertRaises(FontPartsError):
+        with self.assertRaises(TypeError):
             glyph.width = "abc"
 
     def test_width_set_invalid_none(self):
         glyph = self.getGlyph_generic()
-        with self.assertRaises(FontPartsError):
+        with self.assertRaises(TypeError):
             glyph.width = None
 
     # ----

--- a/Lib/fontParts/test/test_groups.py
+++ b/Lib/fontParts/test/test_groups.py
@@ -1,6 +1,5 @@
 import unittest
 import collections
-from fontParts.base import FontPartsError
 
 
 class TestGroups(unittest.TestCase):
@@ -56,7 +55,7 @@ class TestGroups(unittest.TestCase):
 
     def test_find_invalid_key(self):
         groups = self.getGroups_generic()
-        with self.assertRaises(FontPartsError):
+        with self.assertRaises(TypeError):
             groups.findGlyph(5)
 
     # ----

--- a/Lib/fontParts/test/test_guideline.py
+++ b/Lib/fontParts/test/test_guideline.py
@@ -1,6 +1,5 @@
 import unittest
 import collections
-from fontParts.base import FontPartsError
 
 
 class TestGuideline(unittest.TestCase):
@@ -67,7 +66,7 @@ class TestGuideline(unittest.TestCase):
 
     def test_x_set_invalid_string(self):
         guideline = self.getGuideline_generic()
-        with self.assertRaises(FontPartsError):
+        with self.assertRaises(TypeError):
             guideline.x = "ABC"
 
     # y
@@ -121,7 +120,7 @@ class TestGuideline(unittest.TestCase):
 
     def test_y_set_invalid_string(self):
         guideline = self.getGuideline_generic()
-        with self.assertRaises(FontPartsError):
+        with self.assertRaises(TypeError):
             guideline.y = "ABC"
 
     # ----

--- a/Lib/fontParts/test/test_info.py
+++ b/Lib/fontParts/test/test_info.py
@@ -1,6 +1,5 @@
 import unittest
 import collections
-from fontParts.base import FontPartsError
 
 
 class TestInfo(unittest.TestCase):
@@ -39,12 +38,12 @@ class TestInfo(unittest.TestCase):
 
     def test_set_invalid_unitsPerEm_negative(self):
         info = self.getInfo_generic()
-        with self.assertRaises(FontPartsError):
+        with self.assertRaises(ValueError):
             info.unitsPerEm = -1000
 
     def test_set_invalid_unitsPerEm_string(self):
         info = self.getInfo_generic()
-        with self.assertRaises(FontPartsError):
+        with self.assertRaises(ValueError):
             info.unitsPerEm = "abc"
 
     # ----

--- a/Lib/fontParts/test/test_kerning.py
+++ b/Lib/fontParts/test/test_kerning.py
@@ -1,6 +1,5 @@
 import unittest
 import collections
-from fontParts.base import FontPartsError
 
 
 class TestKerning(unittest.TestCase):

--- a/Lib/fontParts/test/test_layer.py
+++ b/Lib/fontParts/test/test_layer.py
@@ -1,6 +1,5 @@
 import unittest
 import collections
-from fontParts.base import FontPartsError
 
 
 class TestLayer(unittest.TestCase):

--- a/Lib/fontParts/test/test_point.py
+++ b/Lib/fontParts/test/test_point.py
@@ -1,6 +1,5 @@
 import unittest
 import collections
-from fontParts.base import FontPartsError
 
 
 class TestPoint(unittest.TestCase):
@@ -59,12 +58,12 @@ class TestPoint(unittest.TestCase):
 
     def test_set_invalid_point_type_string(self):
         point = self.getPoint_generic()
-        with self.assertRaises(FontPartsError):
+        with self.assertRaises(ValueError):
             point.type = "xxx"
 
     def test_set_invalid_point_type_int(self):
         point = self.getPoint_generic()
-        with self.assertRaises(FontPartsError):
+        with self.assertRaises(TypeError):
             point.type = 123
 
     # ----

--- a/Lib/fontParts/test/test_segment.py
+++ b/Lib/fontParts/test/test_segment.py
@@ -1,6 +1,5 @@
 import unittest
 import collections
-from fontParts.base import FontPartsError
 
 
 class TestSegment(unittest.TestCase):
@@ -126,14 +125,13 @@ class TestSegment(unittest.TestCase):
 
     def test_set_invalid_segment_type_string(self):
         segment = self.getSegment_line()
-        with self.assertRaises(FontPartsError):
+        with self.assertRaises(ValueError):
             segment.type = "xxx"
 
     def test_set_invalid_segment_type_int(self):
         segment = self.getSegment_line()
-        with self.assertRaises(FontPartsError):
+        with self.assertRaises(TypeError):
             segment.type = 123
-
 
     # ----
     # Hash


### PR DESCRIPTION
Based on a conversation with @cjchapman, simplify errors to use the base error types if the error fits a `TypeError`, `ValueError`, `IOError`, or `NotImplementedError`.