### PR TITLE
Implement base of glyph.correctDirection.

### DIFF
--- a/Lib/fontParts/base/contour.py
+++ b/Lib/fontParts/base/contour.py
@@ -372,15 +372,18 @@ class BaseContour(BaseObject, TransformationMixin, InterpolationMixin,
         """
         self.raiseNotImplementedError()
 
-    # ------------
-    # Data Queries
-    # ------------
+    # ------------------------
+    # Point and Contour Inside
+    # ------------------------
 
     def pointInside(self, point):
         """
-        Determine if point is in the black or white of the contour.
+        Determine if ``point`` is in the black or white of the contour.
 
-        point must be an (x, y) tuple.
+            >>> contour.pointInside((40, 65))
+            True
+
+        ``point`` must be a :ref:`type-coordinate`.
         """
         point = normalizers.normalizeCoordinateTuple(point)
         return self._pointInside(point)
@@ -393,6 +396,28 @@ class BaseContour(BaseObject, TransformationMixin, InterpolationMixin,
         pen = PointInsidePen(glyphSet=None, testPoint=point, evenOdd=False)
         self.draw(pen)
         return pen.getResult()
+
+    def contourInside(self, otherContour):
+        """
+        Determine if ``otherContour`` is in the black or white of this contour.
+
+            >>> contour.contourInside(otherContour)
+            True
+
+        ``contour`` must be a :class:`BaseContour`.
+        """
+        otherContour = normalizers.normalizeContour(otherContour)
+        return self._contourInside(otherContour)
+
+    def _contourInside(self, otherContour):
+        """
+        Subclasses may override this method.
+        """
+        self.raiseNotImplementedError()
+
+    # ---------------
+    # Bounds and Area
+    # ---------------
 
     bounds = dynamicProperty("bounds",
                              ("The bounds of the contour: "

--- a/Lib/fontParts/base/contour.py
+++ b/Lib/fontParts/base/contour.py
@@ -413,6 +413,25 @@ class BaseContour(BaseObject, TransformationMixin, InterpolationMixin,
         self.draw(pen)
         return pen.bounds
 
+    area = dynamicProperty("area",
+                             ("The area of the contour: "
+                              "A positive number or None."))
+
+    def _get_base_area(self):
+        value = self._get_area()
+        if value is not None:
+            value = normalizers.normalizeArea(value)
+        return value
+
+    def _get_area(self):
+        """
+        Subclasses may override this method.
+        """
+        from fontTools.pens.areaPen import AreaPen
+        pen = AreaPen(self.layer)
+        self.draw(pen)
+        return abs(pen.value)
+
     # --------
     # Segments
     # --------

--- a/Lib/fontParts/base/glyph.py
+++ b/Lib/fontParts/base/glyph.py
@@ -1415,14 +1415,7 @@ class BaseGlyph(BaseObject, TransformationMixin, InterpolationMixin,
 
     def _correctDirection(self, trueType=False, **kwargs):
         """
-        XXX
-
-        This could be ported from RoboFab, however
-        that algorithm is not robust enough. Specifically
-        it relies on bounds and hit testing to
-        determine nesting.
-
-        XXX
+        Subclasses may override this method.
         """
         self.raiseNotImplementedError()
 

--- a/Lib/fontParts/base/glyph.py
+++ b/Lib/fontParts/base/glyph.py
@@ -1872,6 +1872,32 @@ class BaseGlyph(BaseObject, TransformationMixin, InterpolationMixin,
         self.draw(pen)
         return pen.bounds
 
+    area = dynamicProperty(
+        "area",
+        """
+        The area of the glyph as a :ref:`type-int-float` or,
+        in the case of empty glyphs ``None``.
+
+            >>> glyph.area
+            583
+        """
+    )
+
+    def _get_base_area(self):
+        value = self._get_area()
+        if value is not None:
+            value = normalizers.normalizeArea(value)
+        return value
+
+    def _get_area(self):
+        """
+        Subclasses may override this method.
+        """
+        from fontTools.pens.areaPen import AreaPen
+        pen = AreaPen(self.layer)
+        self.draw(pen)
+        return abs(pen.value)
+
     # -----------------
     # Layer Interaction
     # -----------------

--- a/Lib/fontParts/base/normalizers.py
+++ b/Lib/fontParts/base/normalizers.py
@@ -849,6 +849,15 @@ def normalizeBoundingBox(value):
         raise ValueError("Bounding box yMin must be less than or equal to yMax.")
     return tuple([float(v) for v in value])
 
+def normalizeArea(value):
+    """
+    Normalizes area.
+
+    * **value** must be a positive :ref:`type-int-float`.
+    """
+    if not isinstance(value, (int, float)):
+        raise TypeError("Area must be an instance of :ref:`type-int-float`, not %s." % type(value).__name__)
+    return value
 
 # Color
 

--- a/Lib/fontParts/fontshell/contour.py
+++ b/Lib/fontParts/fontshell/contour.py
@@ -56,6 +56,13 @@ class RContour(RBaseObject, BaseContour):
     def _get_bounds(self):
         return self.naked().bounds
 
+    # ----
+    # Area
+    # ----
+
+    def _get_area(self):
+        return self.naked().area
+
     # ---------
     # Direction
     # ---------

--- a/Lib/fontParts/fontshell/contour.py
+++ b/Lib/fontParts/fontshell/contour.py
@@ -49,6 +49,13 @@ class RContour(RBaseObject, BaseContour):
     def _get_open(self):
         return self.naked().open
 
+    # ------
+    # Bounds
+    # ------
+
+    def _get_bounds(self):
+        return self.naked().bounds
+
     # ---------
     # Direction
     # ---------

--- a/Lib/fontParts/fontshell/contour.py
+++ b/Lib/fontParts/fontshell/contour.py
@@ -73,6 +73,16 @@ class RContour(RBaseObject, BaseContour):
     def _reverseContour(self, **kwargs):
         self.naked().reverse()
 
+    # ------------------------
+    # Point and Contour Inside
+    # ------------------------
+
+    def _pointInside(self, point):
+        return self.naked().pointInside(point)
+
+    def _contourInside(self, otherContour):
+        return self.naked().contourInside(otherContour.naked())
+
     # ------
     # Points
     # ------

--- a/Lib/fontParts/fontshell/contour.py
+++ b/Lib/fontParts/fontshell/contour.py
@@ -81,7 +81,7 @@ class RContour(RBaseObject, BaseContour):
         return self.naked().pointInside(point)
 
     def _contourInside(self, otherContour):
-        return self.naked().contourInside(otherContour.naked())
+        return self.naked().contourInside(otherContour.naked(), segmentLength=5)
 
     # ------
     # Points

--- a/Lib/fontParts/fontshell/glyph.py
+++ b/Lib/fontParts/fontshell/glyph.py
@@ -105,6 +105,9 @@ class RGlyph(RBaseObject, BaseGlyph):
         contour = glyph[index]
         glyph.removeContour(contour)
 
+    def _correctDirection(self, trueType=False, **kwargs):
+        self.naked().correctContourDirection(trueType=trueType)
+
     # Components
 
     def _lenComponents(self, **kwargs):

--- a/Lib/fontParts/fontshell/glyph.py
+++ b/Lib/fontParts/fontshell/glyph.py
@@ -62,6 +62,13 @@ class RGlyph(RBaseObject, BaseGlyph):
     def _set_height(self, value):
         self.naked().height = value
 
+    # ------
+    # Bounds
+    # ------
+
+    def _get_bounds(self):
+        return self.naked().bounds
+
     # ----
     # Pens
     # ----

--- a/Lib/fontParts/fontshell/glyph.py
+++ b/Lib/fontParts/fontshell/glyph.py
@@ -70,6 +70,13 @@ class RGlyph(RBaseObject, BaseGlyph):
         return self.naked().bounds
 
     # ----
+    # Area
+    # ----
+
+    def _get_area(self):
+        return self.naked().area
+
+    # ----
     # Pens
     # ----
 


### PR DESCRIPTION
This addresses #146. It is dependent typesupply/defcon#174 on for the fontshell part to work.