### PR TITLE
Layer convenience methods.

### DIFF
--- a/Lib/fontParts/base/font.py
+++ b/Lib/fontParts/base/font.py
@@ -901,14 +901,16 @@ class BaseFont(_BaseGlyphVendor, InterpolationMixin, DeprecatedFont,
         layer2 = self.getLayer(otherLayerName)
         # make a temporary name and assign it to
         # the first layer to prevent two layers
-        # from having the same name at once. 
+        # from having the same name at once.
         layerOrder = self.layerOrder
         for i in range(50):
-            tempLayerName = str(random.randint(4000000, 4999999)) # shout out to PostScript unique IDs
+            # shout out to PostScript unique IDs
+            tempLayerName = str(random.randint(4000000, 4999999))
             if tempLayerName not in layerOrder:
                 break
         if tempLayerName in layerOrder:
-            raise FontPartsError("Couldn't find a temporary layer name after 50 tries. Sorry. Please try again.")
+            raise FontPartsError(("Couldn't find a temporary layer name "
+                                  "after 50 tries. Sorry. Please try again."))
         layer1.name = tempLayerName
         # now swap
         layer2.name = layerName

--- a/Lib/fontParts/base/font.py
+++ b/Lib/fontParts/base/font.py
@@ -788,7 +788,7 @@ class BaseFont(_BaseGlyphVendor, InterpolationMixin, DeprecatedFont,
         """
         Insert **layer** into the font. ::
 
-            >>> glyph = layer.insertGlyph(otherGlyph, name="A")
+            >>> layer = font.insertLayer(otherLayer, name="layer 2")
 
         This does not necessarily insert the layer directly.
         In many cases, the environment will create a new
@@ -828,6 +828,45 @@ class BaseFont(_BaseGlyphVendor, InterpolationMixin, DeprecatedFont,
         dest = self.newLayer(name)
         dest.copyData(layer)
         return dest
+
+    # duplicate
+
+    def duplicateLayer(self, layerName, newLayerName):
+        """
+        Duplicate the layer with **layerName**, assign
+        **newLayerName** to the new layer and insert the
+        new layer into the font. ::
+
+            >>> layer = font.duplicateLayer("layer 1", "layer 2")
+        """
+        layerOrder = self.layerOrder
+        layerName = normalizers.normalizeLayerName(layerName)
+        if layerName not in layerOrder:
+            raise ValueError("No layer with the name '%s' exists." % layerName)
+        newLayerName = normalizers.normalizeLayerName(newLayerName)
+        if newLayerName in layerOrder:
+            raise ValueError("A layer with the name '%s' already exists." % newLayerName)
+        newLayer = self._duplicateLayer(layerName, newLayerName)
+        newLayer = normalizers.normalizeLayer(newLayer)
+        return newLayer
+
+    def _duplicateLayer(self, layerName, newLayerName):
+        """
+        This is the environment implementation of :meth:`BaseFont.duplicateLayer`.
+        **layerName** will be a :ref:`type-string` representing a valid layer name.
+        The value will have been normalized with :func:`normalizers.normalizeLayerName`
+        and **layerName** will be a layer that exists in the font. **newLayerName**
+        will be a :ref:`type-string` representing a valid layer name. The value will
+        have been normalized with :func:`normalizers.normalizeLayerName` and
+        **newLayerName** will have been tested to make sure that no layer with
+        the same name exists in the font. This must return an instance of a
+        :class:`BaseLayer` subclass.
+
+        Subclasses may override this method.
+        """
+
+        newLayer = self.getLayer(layerName).copy()
+        return self.insertLayer(newLayer, newLayerName)
 
     # -----------------
     # Glyph Interaction

--- a/Lib/fontParts/base/font.py
+++ b/Lib/fontParts/base/font.py
@@ -782,6 +782,53 @@ class BaseFont(_BaseGlyphVendor, InterpolationMixin, DeprecatedFont,
         """
         self.raiseNotImplementedError()
 
+    # insert
+
+    def insertLayer(self, layer, name=None):
+        """
+        Insert **layer** into the font. ::
+
+            >>> glyph = layer.insertGlyph(otherGlyph, name="A")
+
+        This does not necessarily insert the layer directly.
+        In many cases, the environment will create a new
+        layer and copy the data from **layer** to the new
+        layer. **name** indicates the name that should be
+        assigned to the layer after insertion. If **name**
+        is not given, the layer's original name must be used.
+        If the layer does not have a name, an error must be raised.
+        The data that will be inserted from **layer** is the
+        same data as documented in :meth:`BaseLayer.copy`.
+        """
+        if name is None:
+            name = layer.name
+        name = normalizers.normalizeLayerName(name)
+        if name in self:
+            self.removeLayer(name)
+        return self._insertLayer(layer, name=name)
+
+    def _insertLayer(self, layer, name, **kwargs):
+        """
+        This is the environment implementation of :meth:`BaseFont.insertLayer`.
+        This must return an instance of a :class:`BaseLayer` subclass.
+        **layer** will be a layer object with the attributes necessary
+        for copying as defined in :meth:`BaseLayer.copy` An environment
+        may choose to not insert **layer** directly, opting to copy
+        the data from **layer** into a new layer instead. **name**
+        will be a :ref:`type-string` representing a glyph layer. It
+        will have been normalized with :func:`normalizers.normalizeLayerName`.
+        **name** will have been tested to make sure that no layer with
+        the same name exists in the font.
+
+        Subclasses may override this method.
+        """
+        if name != layer.name and layer.name in self.layerOrder:
+            layer = layer.copy()
+            layer.name = name
+        dest = self.newLayer(name)
+        dest.copyData(layer)
+        return dest
+
     # -----------------
     # Glyph Interaction
     # -----------------

--- a/Lib/fontParts/base/layer.py
+++ b/Lib/fontParts/base/layer.py
@@ -255,6 +255,9 @@ class _BaseGlyphVendor(BaseObject, DeprecatedLayer, RemovedLayer,
 
         Subclasses may override this method.
         """
+        if name != glyph.name and glyph.name in self:
+            glyph = glyph.copy()
+            glyph.name = name
         dest = self.newGlyph(name)
         dest.copyData(glyph)
         return dest

--- a/Lib/fontParts/base/layer.py
+++ b/Lib/fontParts/base/layer.py
@@ -448,10 +448,12 @@ class BaseLayer(_BaseGlyphVendor, InterpolationMixin):
         if value == self.name:
             return
         value = normalizers.normalizeLayerName(value)
-        existing = self.font.layerOrder
-        if value in existing:
-            raise ValueError("A layer with the name '%s' already exists."
-                             % value)
+        font = self.font
+        if font is not None:
+            existing = self.font.layerOrder
+            if value in existing:
+                raise ValueError("A layer with the name '%s' already exists."
+                                 % value)
         self._set_name(value)
 
     def _get_name(self):


### PR DESCRIPTION
The `duplicateLayer` method is absolutely necessary. I think the `swapLayerNames` method is necessary, but I could use an outside opinion. Even though swapping layers is simple in UI, doing this programmatically is unintuitive, so I figure that we should make this possible.

This addresses #178.