### PR TITLE
Move isEmpty to deprecated.

### DIFF
--- a/Lib/fontParts/base/deprecated.py
+++ b/Lib/fontParts/base/deprecated.py
@@ -331,9 +331,13 @@ class DeprecatedGlyph(DeprecatedBase, DeprecatedTransformation):
         return self.font
 
     def isEmpty(self):
-        warnings.warn("'Glyph.isEmpty()': use 'Glyph.isEmpty'",
+        warnings.warn("'Glyph.isEmpty()': use 'glyph.contours and glyph.components'",
                       DeprecationWarning)
-        return self.isEmpty
+        if self.contours:
+            return False
+        if self.components:
+            return False
+        return True
 
     def readGlyphFromString(self, glifData):
         warnings.warn(("'Glyph.readGlyphFromString()': use "

--- a/Lib/fontParts/base/glyph.py
+++ b/Lib/fontParts/base/glyph.py
@@ -2244,34 +2244,6 @@ class BaseGlyph(BaseObject,
     # API
     # ---
 
-    isEmpty = dynamicProperty(
-        "_isEmpty",
-        """
-        A :ref:`type-bool` indicating the glyph is empty.
-
-            >>> empty = glyph.isEmpty
-
-        This will return ``False`` if the glyph contains
-        any of the following:
-
-        - contours
-        - components
-        - anchors
-        - guidelines
-        """
-    )
-
-    def _get_isEmpty(self):
-        if self.contours:
-            return False
-        if self.components:
-            return False
-        if self.anchors:
-            return False
-        if self.guidelines:
-            return False
-        return True
-
     def loadFromGLIF(self, glifData):
         """
         Reads ``glifData``, in


### PR DESCRIPTION
This restores the behavior as it [was in RoboFab](https://github.com/robofab-developers/robofab/blob/master/Lib/robofab/objects/objectsBase.py#L1463). This should close #148.