### PR TITLE
Fixes insertSegment so that the segment index isn't used as a point index

### DIFF
--- a/Lib/fontParts/base/contour.py
+++ b/Lib/fontParts/base/contour.py
@@ -557,10 +557,11 @@ class BaseContour(
         Subclasses may override this method.
         """
         onCurve = points[-1]
-        offCurve = points[:-1]
-        self.insertPoint(index, onCurve, type=type, smooth=smooth)
+        offCurve = points[:-1]  
+        ptCount = sum([len(self.segments[s].points) for s in range(index)])
+        self.insertPoint(ptCount, onCurve, type=type, smooth=smooth)
         for offCurvePoint in reversed(offCurve):
-            self.insertPoint(index, offCurvePoint, type="offcurve")
+            self.insertPoint(ptCount, offCurvePoint, type="offcurve")
 
     def removeSegment(self, segment):
         """

--- a/Lib/fontParts/base/contour.py
+++ b/Lib/fontParts/base/contour.py
@@ -557,7 +557,7 @@ class BaseContour(
         Subclasses may override this method.
         """
         onCurve = points[-1]
-        offCurve = points[:-1]  
+        offCurve = points[:-1]
         ptCount = sum([len(self.segments[s].points) for s in range(index)])
         self.insertPoint(ptCount, onCurve, type=type, smooth=smooth)
         for offCurvePoint in reversed(offCurve):


### PR DESCRIPTION
`contour.insertPoint()` needs the point index where the segment points should start to be inserted, but it's using the index given to `contour.insertSegment()` which was the segment index. The fix is to add up the total count of points up until the segment index.