### PR TITLE
setup.py: fix issue with False boolean options in bump_version command

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -64,9 +64,13 @@ class bump_version(Command):
 
         args = ['--verbose'] if self.verbose > 1 else []
         for k, v in kwargs.items():
-            k = "--{}".format(k.replace("_", "-"))
-            is_bool = isinstance(v, bool) and v is True
-            args.extend([k] if is_bool else [k, str(v)])
+            arg = "--{}".format(k.replace("_", "-"))
+            if isinstance(v, bool):
+                if v is False:
+                    continue
+                args.append(arg)
+            else:
+                args.extend([arg, str(v)])
         args.append(part)
 
         log.debug(


### PR DESCRIPTION
I noticed yesterday while doing a release of cu2qu (which also uses the custom `bump_version` and `release` setup.py commands) that, when running `setup.py release` without passing the `-s` option (the one that enables GPG signature for the git tag), then the resulting command-line that is passed on to the bumpversion script will contain an invalid `--sign-tags False` argument, and that produces a cryptic error, since the argument is wrongly interpreted by the bumpversion script as being one of the version "parts".
The fix is to completely omit boolean options that have a `False` value from the generated command line.

we should copy the same patch to all the rest of the projects that use these custom commands.

(yeah, I know. I should probably make a setuptools extension that one can simply add to the `setup_requires`, so I can fix this once and for all...)