### PR TITLE
Adds hashability (and related tests) most remaining objects

### DIFF
--- a/Lib/fontParts/base/anchor.py
+++ b/Lib/fontParts/base/anchor.py
@@ -38,6 +38,15 @@ class BaseAnchor(
             contents.append("color=%r" % str(self.color))
         return contents
 
+    def __hash__(self):
+        """
+        Allow anchor object to be used as a key
+        in a dictionary.
+
+        Subclasses may override this method.
+        """
+        return id(self.naked())
+
     # ----
     # Copy
     # ----

--- a/Lib/fontParts/base/component.py
+++ b/Lib/fontParts/base/component.py
@@ -41,6 +41,15 @@ class BaseComponent(
             contents += self.glyph._reprContents()
         return contents
 
+    def __hash__(self):
+        """
+        Allow component object to be used as a key
+        in a dictionary.
+
+        Subclasses may override this method.
+        """
+        return id(self.naked())
+
     # -------
     # Parents
     # -------

--- a/Lib/fontParts/base/contour.py
+++ b/Lib/fontParts/base/contour.py
@@ -43,6 +43,15 @@ class BaseContour(
             selfPoint = self.points[-1]
             selfPoint.copyData(sourcePoint)
 
+    def __hash__(self):
+        """
+        Allow contour object to be used as a key
+        in a dictionary.
+
+        Subclasses may override this method.
+        """
+        return id(self.naked())
+
     # -------
     # Parents
     # -------

--- a/Lib/fontParts/base/guideline.py
+++ b/Lib/fontParts/base/guideline.py
@@ -51,6 +51,15 @@ class BaseGuideline(
             contents.append("('%s')" % self.layer.name)
         return contents
 
+    def __hash__(self):
+        """
+        Allow bPoint object to be used as a key
+        in a dictionary.
+
+        Subclasses may override this method.
+        """
+        return id(self.naked())
+
     # -------
     # Parents
     # -------

--- a/Lib/fontParts/base/image.py
+++ b/Lib/fontParts/base/image.py
@@ -38,6 +38,15 @@ class BaseImage(
             contents += self.glyph._reprContents()
         return contents
 
+    def __hash__(self):
+        """
+        Allow image object to be used as a key
+        in a dictionary.
+
+        Subclasses may override this method.
+        """
+        return id(self.naked())
+
     def __bool__(self):
         if len(self.data) == 0 or self.data is None:
             return False

--- a/Lib/fontParts/base/layer.py
+++ b/Lib/fontParts/base/layer.py
@@ -366,6 +366,15 @@ class BaseLayer(_BaseGlyphVendor, InterpolationMixin):
             contents.append("color=%r" % str(self.color))
         return contents
 
+    def __hash__(self):
+        """
+        Allow layer object to be used as a key
+        in a dictionary.
+
+        Subclasses may override this method.
+        """
+        return id(self.naked())
+
     # ----
     # Copy
     # ----

--- a/Lib/fontParts/base/point.py
+++ b/Lib/fontParts/base/point.py
@@ -51,6 +51,15 @@ class BasePoint(
             contents.append("smooth=%r" % self.smooth)
         return contents
 
+    def __hash__(self):
+        """
+        Allow point object to be used as a key
+        in a dictionary.
+
+        Subclasses may override this method.
+        """
+        return id(self.naked())
+
     # -------
     # Parents
     # -------

--- a/Lib/fontParts/test/test_anchor.py
+++ b/Lib/fontParts/test/test_anchor.py
@@ -500,11 +500,43 @@ class TestAnchor(unittest.TestCase):
     # ----
     # Hash
     # ----
-    def test_hash(self):
-        anchor = self.getAnchor_generic()
+
+    def test_hash_object_self(self):
+        anchor_one = self.getAnchor_generic()
         self.assertEqual(
-            isinstance(anchor, collections.Hashable),
-            False
+            hash(anchor_one),
+            hash(anchor_one)
+        )
+
+    def test_hash_object_other(self):
+        anchor_one = self.getAnchor_generic()
+        anchor_two = self.getAnchor_generic()
+        self.assertNotEqual(
+            hash(anchor_one),
+            hash(anchor_two)
+        )
+
+    def test_hash_object_self_variable_assignment(self):
+        anchor_one = self.getAnchor_generic()
+        a = anchor_one
+        self.assertEqual(
+            hash(anchor_one),
+            hash(a)
+        )
+
+    def test_hash_object_other_variable_assignment(self):
+        anchor_one = self.getAnchor_generic()
+        anchor_two = self.getAnchor_generic()
+        a = anchor_one
+        self.assertNotEqual(
+            hash(anchor_two),
+            hash(a)
+        )
+
+    def test_is_hashable(self):
+        anchor_one = self.getAnchor_generic()
+        self.assertTrue(
+            isinstance(anchor_one, collections.Hashable)
         )
 
     # -------

--- a/Lib/fontParts/test/test_component.py
+++ b/Lib/fontParts/test/test_component.py
@@ -813,11 +813,42 @@ class TestComponent(unittest.TestCase):
     # Hash
     # ----
 
-    def test_hash(self):
-        component = self.getComponent_generic()
+    def test_hash_object_self(self):
+        component_one = self.getComponent_generic()
         self.assertEqual(
-            isinstance(component, collections.Hashable),
-            False
+            hash(component_one),
+            hash(component_one)
+        )
+
+    def test_hash_object_other(self):
+        component_one = self.getComponent_generic()
+        component_two = self.getComponent_generic()
+        self.assertNotEqual(
+            hash(component_one),
+            hash(component_two)
+        )
+
+    def test_hash_object_self_variable_assignment(self):
+        component_one = self.getComponent_generic()
+        a = component_one
+        self.assertEqual(
+            hash(component_one),
+            hash(a)
+        )
+
+    def test_hash_object_other_variable_assignment(self):
+        component_one = self.getComponent_generic()
+        component_two = self.getComponent_generic()
+        a = component_one
+        self.assertNotEqual(
+            hash(component_two),
+            hash(a)
+        )
+
+    def test_is_hashable(self):
+        component_one = self.getComponent_generic()
+        self.assertTrue(
+            isinstance(component_one, collections.Hashable)
         )
 
     # --------

--- a/Lib/fontParts/test/test_contour.py
+++ b/Lib/fontParts/test/test_contour.py
@@ -60,11 +60,42 @@ class TestContour(unittest.TestCase):
     # Hash
     # ----
 
-    def test_hash(self):
-        contour = self.getContour_bounds()
+    def test_hash_object_self(self):
+        contour_one = self.getContour_bounds()
         self.assertEqual(
-            isinstance(contour, collections.Hashable),
-            False
+            hash(contour_one),
+            hash(contour_one)
+        )
+
+    def test_hash_object_other(self):
+        contour_one = self.getContour_bounds()
+        contour_two = self.getContour_bounds()
+        self.assertNotEqual(
+            hash(contour_one),
+            hash(contour_two)
+        )
+
+    def test_hash_object_self_variable_assignment(self):
+        contour_one = self.getContour_bounds()
+        a = contour_one
+        self.assertEqual(
+            hash(contour_one),
+            hash(a)
+        )
+
+    def test_hash_object_other_variable_assignment(self):
+        contour_one = self.getContour_bounds()
+        contour_two = self.getContour_bounds()
+        a = contour_one
+        self.assertNotEqual(
+            hash(contour_two),
+            hash(a)
+        )
+
+    def test_is_hashable(self):
+        contour_one = self.getContour_bounds()
+        self.assertTrue(
+            isinstance(contour_one, collections.Hashable)
         )
 
     # --------

--- a/Lib/fontParts/test/test_guideline.py
+++ b/Lib/fontParts/test/test_guideline.py
@@ -609,11 +609,42 @@ class TestGuideline(unittest.TestCase):
     # Hash
     # ----
 
-    def test_hash(self):
-        guideline = self.getGuideline_generic()
+    def test_hash_object_self(self):
+        guideline_one = self.getGuideline_generic()
         self.assertEqual(
-            isinstance(guideline, collections.Hashable),
-            False
+            hash(guideline_one),
+            hash(guideline_one)
+        )
+
+    def test_hash_object_other(self):
+        guideline_one = self.getGuideline_generic()
+        guideline_two = self.getGuideline_generic()
+        self.assertNotEqual(
+            hash(guideline_one),
+            hash(guideline_two)
+        )
+
+    def test_hash_object_self_variable_assignment(self):
+        guideline_one = self.getGuideline_generic()
+        a = guideline_one
+        self.assertEqual(
+            hash(guideline_one),
+            hash(a)
+        )
+
+    def test_hash_object_other_variable_assignment(self):
+        guideline_one = self.getGuideline_generic()
+        guideline_two = self.getGuideline_generic()
+        a = guideline_one
+        self.assertNotEqual(
+            hash(guideline_two),
+            hash(a)
+        )
+
+    def test_is_hashable(self):
+        guideline_one = self.getGuideline_generic()
+        self.assertTrue(
+            isinstance(guideline_one, collections.Hashable)
         )
 
     # --------

--- a/Lib/fontParts/test/test_image.py
+++ b/Lib/fontParts/test/test_image.py
@@ -353,11 +353,42 @@ class TestImage(unittest.TestCase):
     # Hash
     # ----
 
-    def test_hash(self):
-        image = self.getImage_generic()
+    def test_hash_object_self(self):
+        image_one = self.getImage_generic()
         self.assertEqual(
-            isinstance(image, collections.Hashable),
-            False
+            hash(image_one),
+            hash(image_one)
+        )
+
+    def test_hash_object_other(self):
+        image_one = self.getImage_generic()
+        image_two = self.getImage_generic()
+        self.assertNotEqual(
+            hash(image_one),
+            hash(image_two)
+        )
+
+    def test_hash_object_self_variable_assignment(self):
+        image_one = self.getImage_generic()
+        a = image_one
+        self.assertEqual(
+            hash(image_one),
+            hash(a)
+        )
+
+    def test_hash_object_other_variable_assignment(self):
+        image_one = self.getImage_generic()
+        image_two = self.getImage_generic()
+        a = image_one
+        self.assertNotEqual(
+            hash(image_two),
+            hash(a)
+        )
+
+    def test_is_hashable(self):
+        image_one = self.getImage_generic()
+        self.assertTrue(
+            isinstance(image_one, collections.Hashable)
         )
 
     # --------

--- a/Lib/fontParts/test/test_layer.py
+++ b/Lib/fontParts/test/test_layer.py
@@ -25,11 +25,42 @@ class TestLayer(unittest.TestCase):
     # Hash
     # ----
 
-    def test_hash(self):
-        layer = self.getLayer_glyphs()
+    def test_hash_object_self(self):
+        layer_one = self.getLayer_glyphs()
         self.assertEqual(
-            isinstance(layer, collections.Hashable),
-            False
+            hash(layer_one),
+            hash(layer_one)
+        )
+
+    def test_hash_object_other(self):
+        layer_one = self.getLayer_glyphs()
+        layer_two = self.getLayer_glyphs()
+        self.assertNotEqual(
+            hash(layer_one),
+            hash(layer_two)
+        )
+
+    def test_hash_object_self_variable_assignment(self):
+        layer_one = self.getLayer_glyphs()
+        a = layer_one
+        self.assertEqual(
+            hash(layer_one),
+            hash(a)
+        )
+
+    def test_hash_object_other_variable_assignment(self):
+        layer_one = self.getLayer_glyphs()
+        layer_two = self.getLayer_glyphs()
+        a = layer_one
+        self.assertNotEqual(
+            hash(layer_two),
+            hash(a)
+        )
+
+    def test_is_hashable(self):
+        layer_one = self.getLayer_glyphs()
+        self.assertTrue(
+            isinstance(layer_one, collections.Hashable)
         )
 
     # --------

--- a/Lib/fontParts/test/test_point.py
+++ b/Lib/fontParts/test/test_point.py
@@ -420,11 +420,42 @@ class TestPoint(unittest.TestCase):
     # Hash
     # ----
 
-    def test_hash(self):
-        point = self.getPoint_generic()
+    def test_hash_object_self(self):
+        point_one = self.getPoint_generic()
         self.assertEqual(
-            isinstance(point, collections.Hashable),
-            False
+            hash(point_one),
+            hash(point_one)
+        )
+
+    def test_hash_object_other(self):
+        point_one = self.getPoint_generic()
+        point_two = self.getPoint_generic()
+        self.assertNotEqual(
+            hash(point_one),
+            hash(point_two)
+        )
+
+    def test_hash_object_self_variable_assignment(self):
+        point_one = self.getPoint_generic()
+        a = point_one
+        self.assertEqual(
+            hash(point_one),
+            hash(a)
+        )
+
+    def test_hash_object_other_variable_assignment(self):
+        point_one = self.getPoint_generic()
+        point_two = self.getPoint_generic()
+        a = point_one
+        self.assertNotEqual(
+            hash(point_two),
+            hash(a)
+        )
+
+    def test_is_hashable(self):
+        point_one = self.getPoint_generic()
+        self.assertTrue(
+            isinstance(point_one, collections.Hashable)
         )
 
     # --------


### PR DESCRIPTION
Related to #52 and #118, I think it's useful to have more objects be hashable. Ben had already added this functionality to the `font` and `glyph` objects so I followed the same pattern and added `__hash__` and its related tests to `anchor`, `component`, `contour`, `guideline`, `image`, `layer`, and `point` objects. 

The only two other objects that I didn't add this to, and that I think it could still be useful to have, are the `bPoint` and `segment` objects — I think I was running into problems because these are built dynamically.