### PR TITLE
Remove asserts

### DIFF
--- a/Lib/fontParts/base/anchor.py
+++ b/Lib/fontParts/base/anchor.py
@@ -65,7 +65,8 @@ class BaseAnchor(
         return self._glyph()
 
     def _set_glyph(self, glyph):
-        assert self._glyph is None
+        if self._glyph is not None:
+            raise AssertionError("glyph for anchor already set")
         if glyph is not None:
             glyph = reference(glyph)
         self._glyph = glyph

--- a/Lib/fontParts/base/bPoint.py
+++ b/Lib/fontParts/base/bPoint.py
@@ -29,7 +29,8 @@ class BaseBPoint(
         return contents
 
     def _setPoint(self, point):
-        assert not hasattr(self, "_point")
+        if hasattr(self, "_point"):
+            raise AssertionError("point for bPoint already set")
         self._point = point
 
     def __eq__(self, other):
@@ -96,7 +97,8 @@ class BaseBPoint(
         return self._contour()
 
     def _set_contour(self, contour):
-        assert self._contour is None
+        if self._contour is not None:
+            raise AssertionError("contour for bPoint already set")
         if contour is not None:
             contour = reference(contour)
         self._contour = contour

--- a/Lib/fontParts/base/component.py
+++ b/Lib/fontParts/base/component.py
@@ -57,7 +57,8 @@ class BaseComponent(
         return self._glyph()
 
     def _set_glyph(self, glyph):
-        assert self._glyph is None
+        if self._glyph is not None:
+            raise AssertionError("glyph for component already set")
         if glyph is not None:
             glyph = reference(glyph)
         self._glyph = glyph

--- a/Lib/fontParts/base/contour.py
+++ b/Lib/fontParts/base/contour.py
@@ -60,7 +60,8 @@ class BaseContour(
         return self._glyph()
 
     def _set_glyph(self, glyph):
-        assert self._glyph is None
+        if self._glyph is not None:
+            raise AssertionError("glyph for contour already set")
         if glyph is not None:
             glyph = reference(glyph)
         self._glyph = glyph
@@ -491,7 +492,8 @@ class BaseContour(
             del segments[-1]
         if lastWasOffCurve and not firstIsMove:
             segment = segments.pop(-1)
-            assert len(segments[0]) == 1
+            if len(segments[0]) != 1:
+                raise AssertionError("Length of segments[0] is not 1")
             segment.append(segments[0][0])
             del segments[0]
             segments.append(segment)

--- a/Lib/fontParts/base/features.py
+++ b/Lib/fontParts/base/features.py
@@ -30,8 +30,8 @@ class BaseFeatures(BaseObject, DeprecatedFeatures, RemovedFeatures):
         return self._font()
 
     def _set_font(self, font):
-        if self._font is not None or self._font != font:
-            raise AssertionError("font for features already set or is not same font")
+        if self._font is not None and self._font() != font:
+            raise AssertionError("font for features already set and is not same as font")
         if font is not None:
             font = reference(font)
         self._font = font

--- a/Lib/fontParts/base/features.py
+++ b/Lib/fontParts/base/features.py
@@ -30,7 +30,8 @@ class BaseFeatures(BaseObject, DeprecatedFeatures, RemovedFeatures):
         return self._font()
 
     def _set_font(self, font):
-        assert self._font is None or self._font() == font
+        if self._font is not None or self._font != font:
+            raise AssertionError("font for features already set or is not same font")
         if font is not None:
             font = reference(font)
         self._font = font

--- a/Lib/fontParts/base/groups.py
+++ b/Lib/fontParts/base/groups.py
@@ -46,7 +46,8 @@ class BaseGroups(BaseDict, DeprecatedGroups, RemovedGroups):
         return self._font()
 
     def _set_font(self, font):
-        assert self._font is None or self._font() == font
+        if self._font is not None or self._font != font:
+            raise AssertionError("font for groups already set or is not same font")
         if font is not None:
             font = reference(font)
         self._font = font

--- a/Lib/fontParts/base/groups.py
+++ b/Lib/fontParts/base/groups.py
@@ -46,8 +46,8 @@ class BaseGroups(BaseDict, DeprecatedGroups, RemovedGroups):
         return self._font()
 
     def _set_font(self, font):
-        if self._font is not None or self._font != font:
-            raise AssertionError("font for groups already set or is not same font")
+        if self._font is not None and self._font != font:
+            raise AssertionError("font for groups already set and is not same as font")
         if font is not None:
             font = reference(font)
         self._font = font

--- a/Lib/fontParts/base/guideline.py
+++ b/Lib/fontParts/base/guideline.py
@@ -67,8 +67,10 @@ class BaseGuideline(
         return self._glyph()
 
     def _set_glyph(self, glyph):
-        assert self._font is None
-        assert self._glyph is None
+        if self._font is not None:
+            raise AssertionError("font for guideline already set")
+        if self._glyph is not None:
+            raise AssertionError("glyph for guideline already set")
         if glyph is not None:
             glyph = reference(glyph)
         self._glyph = glyph
@@ -96,8 +98,10 @@ class BaseGuideline(
         return None
 
     def _set_font(self, font):
-        assert self._font is None
-        assert self._glyph is None
+        if self._font is not None:
+            raise AssertionError("font for guideline already set")
+        if self._glyph is not None:
+            raise AssertionError("glyph for guideline already set")
         if font is not None:
             font = reference(font)
         self._font = font

--- a/Lib/fontParts/base/image.py
+++ b/Lib/fontParts/base/image.py
@@ -62,7 +62,8 @@ class BaseImage(
         return self._glyph()
 
     def _set_glyph(self, glyph):
-        assert self._glyph is None
+        if self._glyph is not None:
+            raise AssertionError("glyph for image already set")
         if glyph is not None:
             glyph = reference(glyph)
         self._glyph = glyph

--- a/Lib/fontParts/base/info.py
+++ b/Lib/fontParts/base/info.py
@@ -38,8 +38,8 @@ class BaseInfo(BaseObject, DeprecatedInfo, RemovedInfo):
         return self._font()
 
     def _set_font(self, font):
-        if self._font is not None or self._font != font:
-            raise AssertionError("font for info already set or is not same font")
+        if self._font is not None and self._font != font:
+            raise AssertionError("font for info already set and is not same as font")
         if font is not None:
             font = reference(font)
         self._font = font

--- a/Lib/fontParts/base/info.py
+++ b/Lib/fontParts/base/info.py
@@ -38,7 +38,8 @@ class BaseInfo(BaseObject, DeprecatedInfo, RemovedInfo):
         return self._font()
 
     def _set_font(self, font):
-        assert self._font is None or self._font() == font
+        if self._font is not None or self._font != font:
+            raise AssertionError("font for info already set or is not same font")
         if font is not None:
             font = reference(font)
         self._font = font

--- a/Lib/fontParts/base/kerning.py
+++ b/Lib/fontParts/base/kerning.py
@@ -52,8 +52,8 @@ class BaseKerning(BaseDict, DeprecatedKerning, RemovedKerning):
         return self._font()
 
     def _set_font(self, font):
-        if self._font is not None or self._font != font:
-            raise AssertionError("font for kerning already set or is not same font")
+        if self._font is not None and self._font() != font:
+            raise AssertionError("font for kerning already set and is not same as font")
         if font is not None:
             font = reference(font)
         self._font = font

--- a/Lib/fontParts/base/kerning.py
+++ b/Lib/fontParts/base/kerning.py
@@ -52,7 +52,8 @@ class BaseKerning(BaseDict, DeprecatedKerning, RemovedKerning):
         return self._font()
 
     def _set_font(self, font):
-        assert self._font is None or self._font() == font
+        if self._font is not None or self._font != font:
+            raise AssertionError("font for kerning already set or is not same font")
         if font is not None:
             font = reference(font)
         self._font = font

--- a/Lib/fontParts/base/layer.py
+++ b/Lib/fontParts/base/layer.py
@@ -424,7 +424,8 @@ class BaseLayer(_BaseGlyphVendor, InterpolationMixin, DeprecatedLayer, RemovedLa
         return self._font()
 
     def _set_font(self, font):
-        assert self._font is None
+        if self._font is not None:
+            raise AssertionError("font for layer already set")
         if font is not None:
             font = reference(font)
         self._font = font

--- a/Lib/fontParts/base/lib.py
+++ b/Lib/fontParts/base/lib.py
@@ -49,8 +49,10 @@ class BaseLib(BaseDict, DeprecatedLib, RemovedLib):
         return self._glyph()
 
     def _set_glyph(self, glyph):
-        assert self._font is None
-        assert self._glyph is None or self._glyph() == glyph
+        if self._font is not None:
+            raise AssertionError("font for lib already set")
+        if self._glyph is not None or self._glyph != glyph:
+            raise AssertionError("glyph for lib already set or glyph is different")
         if glyph is not None:
             glyph = reference(glyph)
         self._glyph = glyph
@@ -69,8 +71,10 @@ class BaseLib(BaseDict, DeprecatedLib, RemovedLib):
         return None
 
     def _set_font(self, font):
-        assert self._font is None or self._font() == font
-        assert self._glyph is None
+        if self._font is not None or self._font != font:
+            raise AssertionError("font for lib already set or font is different")
+        if self._glyph is not None:
+            raise AssertionError("glyph for lib already set")
         if font is not None:
             font = reference(font)
         self._font = font

--- a/Lib/fontParts/base/lib.py
+++ b/Lib/fontParts/base/lib.py
@@ -51,8 +51,8 @@ class BaseLib(BaseDict, DeprecatedLib, RemovedLib):
     def _set_glyph(self, glyph):
         if self._font is not None:
             raise AssertionError("font for lib already set")
-        if self._glyph is not None or self._glyph != glyph:
-            raise AssertionError("glyph for lib already set or glyph is different")
+        if self._glyph is not None and self._glyph() != glyph:
+            raise AssertionError("glyph for lib already set and is not same as glyph")
         if glyph is not None:
             glyph = reference(glyph)
         self._glyph = glyph
@@ -71,8 +71,8 @@ class BaseLib(BaseDict, DeprecatedLib, RemovedLib):
         return None
 
     def _set_font(self, font):
-        if self._font is not None or self._font != font:
-            raise AssertionError("font for lib already set or font is different")
+        if self._font is not None and self._font() != font:
+            raise AssertionError("font for lib already set and is not same as font")
         if self._glyph is not None:
             raise AssertionError("glyph for lib already set")
         if font is not None:

--- a/Lib/fontParts/base/point.py
+++ b/Lib/fontParts/base/point.py
@@ -68,7 +68,8 @@ class BasePoint(
         return self._contour()
 
     def _set_contour(self, contour):
-        assert self._contour is None
+        if self._contour is not None:
+            raise AssertionError("contour for point already set")
         if contour is not None:
             contour = reference(contour)
         self._contour = contour

--- a/Lib/fontParts/base/segment.py
+++ b/Lib/fontParts/base/segment.py
@@ -22,7 +22,8 @@ class BaseSegment(
                   ):
 
     def _setPoints(self, points):
-        assert not hasattr(self, "_points")
+        if hasattr(self, "_points"):
+            raise AssertionError("segment has points")
         self._points = points
 
     def _reprContents(self):
@@ -54,7 +55,8 @@ class BaseSegment(
         return self._contour()
 
     def _set_contour(self, contour):
-        assert self._contour is None
+        if self._contour is not None:
+            raise AssertionError("contour for segment already set")
         if contour is not None:
             contour = reference(contour)
         self._contour = contour


### PR DESCRIPTION
Removes asserts and replaces with a comparison check and a better detailed AssertionError message. Avoids ``assert`` being removed from complied byte code. Or so says Codacy.