### PR TITLE
Bring isEmpty back

### DIFF
--- a/Lib/fontParts/base/deprecated.py
+++ b/Lib/fontParts/base/deprecated.py
@@ -367,15 +367,6 @@ class DeprecatedGlyph(DeprecatedBase, DeprecatedTransformation):
                       DeprecationWarning)
         return self.font
 
-    def isEmpty(self):
-        warnings.warn("'Glyph.isEmpty()': use 'glyph.contours and glyph.components'",
-                      DeprecationWarning)
-        if self.contours:
-            return False
-        if self.components:
-            return False
-        return True
-
     def readGlyphFromString(self, glifData):
         warnings.warn(("'Glyph.readGlyphFromString()': use "
                        "'Glyph.loadFromGLIF()'"),
@@ -387,6 +378,11 @@ class DeprecatedGlyph(DeprecatedBase, DeprecatedTransformation):
                        "'Glyph.dumpToGLIF()'"),
                       DeprecationWarning)
         return self.dumpToGLIF(glyphFormatVersion)
+
+    def isEmpty(self):
+        warnings.warn("'Glyph.isEmpty()': use 'Glyph.isEmpty'",
+                      DeprecationWarning)
+        return self.isEmpty
 
 # =============
 # = Guideline =

--- a/Lib/fontParts/base/deprecated.py
+++ b/Lib/fontParts/base/deprecated.py
@@ -379,10 +379,6 @@ class DeprecatedGlyph(DeprecatedBase, DeprecatedTransformation):
                       DeprecationWarning)
         return self.dumpToGLIF(glyphFormatVersion)
 
-    def isEmpty(self):
-        warnings.warn("'Glyph.isEmpty()': use 'Glyph.isEmpty'",
-                      DeprecationWarning)
-        return self.isEmpty
 
 # =============
 # = Guideline =

--- a/Lib/fontParts/base/glyph.py
+++ b/Lib/fontParts/base/glyph.py
@@ -2243,7 +2243,7 @@ class BaseGlyph(BaseObject,
     # ---
 
     isEmpty = dynamicProperty(
-            "_isEmpty",
+            "isEmpty",
             """
             A :ref:`type-bool` indicating the glyph is empty.
 

--- a/Lib/fontParts/base/glyph.py
+++ b/Lib/fontParts/base/glyph.py
@@ -2242,6 +2242,28 @@ class BaseGlyph(BaseObject,
     # API
     # ---
 
+    isEmpty = dynamicProperty(
+            "_isEmpty",
+            """
+            A :ref:`type-bool` indicating the glyph is empty.
+
+                >>> empty = glyph.isEmpty
+
+            This will return ``False`` if the glyph contains
+            any of the following:
+
+            - contours
+            - components
+            """
+        )
+
+    def _get_isEmpty(self):
+        if self.contours:
+            return False
+        if self.components:
+            return False
+        return True
+
     def loadFromGLIF(self, glifData):
         """
         Reads ``glifData``, in

--- a/Lib/fontParts/base/glyph.py
+++ b/Lib/fontParts/base/glyph.py
@@ -2244,13 +2244,14 @@ class BaseGlyph(BaseObject,
 
     def isEmpty(self):
         """
-        This will return :ref:`type-bool` indicating if there are contours or
-        components in the glyph. If there are no contours and components in
-        the glyph, it returns `True`. If there are contours, compnents, or
-        both it returns `False`.
+        This will return :ref:`type-bool` indicating if there are contours and/or
+        components in the glyph.
 
             >>> glyph.isEmpty()
 
+        Note: This method only checks for the presence of contours and components.
+        Other attributes (guidelines, anchors, a lib, etc.) will not affect what
+        this method returns.
         """
         if self.contours:
             return False

--- a/Lib/fontParts/base/glyph.py
+++ b/Lib/fontParts/base/glyph.py
@@ -2242,22 +2242,16 @@ class BaseGlyph(BaseObject,
     # API
     # ---
 
-    isEmpty = dynamicProperty(
-            "isEmpty",
-            """
-            A :ref:`type-bool` indicating the glyph is empty.
+    def isEmpty(self):
+        """
+        This will return :ref:`type-bool` indicating if there are contours or
+        components in the glyph. If there are no contours and components in
+        the glyph, it returns `True`. If there are contours, compnents, or
+        both it returns `False`.
 
-                >>> empty = glyph.isEmpty
+            >>> glyph.isEmpty()
 
-            This will return ``False`` if the glyph contains
-            any of the following:
-
-            - contours
-            - components
-            """
-        )
-
-    def _get_isEmpty(self):
+        """
         if self.contours:
             return False
         if self.components:

--- a/Lib/fontParts/test/test_deprecated.py
+++ b/Lib/fontParts/test/test_deprecated.py
@@ -878,15 +878,15 @@ class TestDeprecated(unittest.TestCase):
 
     def test_glyph_deprecated_isEmpty(self):
         glyph = self.getGlyph_generic()
-        with self.assertWarnsRegex(DeprecationWarning, "Glyph.isEmpty()"):
+        with self.assertWarnsRegex(DeprecationWarning, "Glyph.isEmpty"):
             v = glyph.isEmpty()
         self.assertFalse(v)
         glyph.clear()
-        with self.assertWarnsRegex(DeprecationWarning, "Glyph.isEmpty()"):
+        with self.assertWarnsRegex(DeprecationWarning, "Glyph.isEmpty"):
             v = glyph.isEmpty()
         self.assertTrue(v)
         glyph.appendComponent("component 1")
-        with self.assertWarnsRegex(DeprecationWarning, "Glyph.isEmpty()"):
+        with self.assertWarnsRegex(DeprecationWarning, "Glyph.isEmpty"):
             v = glyph.isEmpty()
         self.assertFalse(v)
 

--- a/Lib/fontParts/test/test_deprecated.py
+++ b/Lib/fontParts/test/test_deprecated.py
@@ -876,20 +876,6 @@ class TestDeprecated(unittest.TestCase):
             parent = glyph.getParent()
         self.assertEqual(parent, glyph.font)
 
-    def test_glyph_deprecated_isEmpty(self):
-        glyph = self.getGlyph_generic()
-        with self.assertWarnsRegex(DeprecationWarning, "Glyph.isEmpty"):
-            v = glyph.isEmpty()
-        self.assertFalse(v)
-        glyph.clear()
-        with self.assertWarnsRegex(DeprecationWarning, "Glyph.isEmpty"):
-            v = glyph.isEmpty()
-        self.assertTrue(v)
-        glyph.appendComponent("component 1")
-        with self.assertWarnsRegex(DeprecationWarning, "Glyph.isEmpty"):
-            v = glyph.isEmpty()
-        self.assertFalse(v)
-
     def test_glyph_deprecated_writeGlyphToString(self):
         glyph = self.getGlyph_generic()
         with self.assertWarnsRegex(DeprecationWarning, "Glyph.dumpToGLIF()"):

--- a/Lib/fontParts/test/test_glyph.py
+++ b/Lib/fontParts/test/test_glyph.py
@@ -857,18 +857,18 @@ class TestGlyph(unittest.TestCase):
 
     def test_isEmpty_false_outlines(self):
         glyph = self.getGlyph_generic()
-        self.assertFalse(glyph.isEmpty)
+        self.assertFalse(glyph.isEmpty())
 
     def test_isEmpty_true_clear(self):
         glyph = self.getGlyph_generic()
         glyph.clear()
-        self.assertTrue(glyph.isEmpty)
+        self.assertTrue(glyph.isEmpty())
 
     def test_isEmpty_false_component(self):
         glyph = self.getGlyph_generic()
         glyph.clear()
         glyph.appendComponent("component 1")
-        self.assertFalse(glyph.isEmpty)
+        self.assertFalse(glyph.isEmpty())
 
 
 def test_generator(test_name, metric, value):

--- a/Lib/fontParts/test/test_glyph.py
+++ b/Lib/fontParts/test/test_glyph.py
@@ -851,6 +851,24 @@ class TestGlyph(unittest.TestCase):
             ()
         )
 
+    # ---
+    # API
+    # ---
+
+    def test_isEmpty_false_outlines(self):
+        glyph = self.getGlyph_generic()
+        self.assertFalse(glyph.isEmpty)
+
+    def test_isEmpty_true_clear(self):
+        glyph = self.getGlyph_generic()
+        glyph.clear()
+        self.assertTrue(glyph.isEmpty)
+
+    def test_isEmpty_false_component(self):
+        glyph = self.getGlyph_generic()
+        glyph.clear()
+        glyph.appendComponent("component 1")
+        self.assertFalse(glyph.isEmpty)
 
 def test_generator(test_name, metric, value):
     if '_invalid_' in test_name:

--- a/Lib/fontParts/test/test_glyph.py
+++ b/Lib/fontParts/test/test_glyph.py
@@ -870,6 +870,7 @@ class TestGlyph(unittest.TestCase):
         glyph.appendComponent("component 1")
         self.assertFalse(glyph.isEmpty)
 
+
 def test_generator(test_name, metric, value):
     if '_invalid_' in test_name:
         def test(self):


### PR DESCRIPTION
This brings it back as a property, with the significant disadvantage that I don't see how to deprecate `isEmpty()` as a method (as `isEmpty` is now a bool, so...). As a property this feels right, as opposed to a method, but we can keep it as a method if that's easier.