### PR TITLE
Use `defaultLayerName`

### DIFF
--- a/Lib/fontParts/test/test_glyph.py
+++ b/Lib/fontParts/test/test_glyph.py
@@ -211,12 +211,11 @@ class TestGlyph(unittest.TestCase):
     def test_get_layers(self):
         font = self.get_generic_object("font")
         glyph = font.newGlyph("A")
-        glyph.layer.name = "test"
         layers = glyph.layers
         self.assertEqual(len(layers), 1)
         self.assertEqual(
             glyph.layer.name,
-            'test'
+            font.defaultLayerName
         )
         self.assertEqual(
             layers[0],
@@ -237,9 +236,8 @@ class TestGlyph(unittest.TestCase):
     def test_getLayer_valid(self):
         font = self.get_generic_object("font")
         glyph = font.newGlyph("B")
-        glyph.layer.name = "test"
         self.assertEqual(
-            glyph.getLayer('test').name,
+            glyph.getLayer(font.defaultLayerName).name,
             'B'
         )
 
@@ -294,9 +292,8 @@ class TestGlyph(unittest.TestCase):
     def test_removeLayer_valid_type_string(self):
         font = self.get_generic_object("font")
         glyph = font.newGlyph("D")
-        glyph.layer.name = "test"
         self.assertEqual(len(glyph.layers), 1)
-        glyph.removeLayer('test')
+        glyph.removeLayer(font.defaultLayerName)
         self.assertEqual(len(glyph.layers), 0)
 
     def test_removeLayer_valid_type_glyph_layer(self):


### PR DESCRIPTION
In tests that had `public.default` hard coded. This should use the default layer name from the environment.