### PR TITLE
Adds more tests for the guideline, and makes a bug fix in fontShell...

### DIFF
--- a/Lib/fontParts/fontshell/font.py
+++ b/Lib/fontParts/fontshell/font.py
@@ -149,6 +149,7 @@ class RFont(RBaseObject, BaseFont):
         guideline = self.guidelineClass().naked()
         guideline.x = position[0]
         guideline.y = position[1]
+        guideline.angle = angle
         guideline.name = name
         guideline.color = color
         self.naked().appendGuideline(guideline)

--- a/Lib/fontParts/test/test_guideline.py
+++ b/Lib/fontParts/test/test_guideline.py
@@ -11,23 +11,85 @@ class TestGuideline(unittest.TestCase):
         guideline.x = 1
         guideline.y = 2
         guideline.angle = 90
+        guideline.name = "Test Guideline"
         return guideline
+        
+    def getGuideline_fontGuideline(self):
+        font, _ = self.objectGenerator("font")
+        guideline = font.appendGuideline((1, 2), 90, "Test Guideline Font")
+        return guideline
+        
+    def getGuideline_glyphGuideline(self):
+        font, _ = self.objectGenerator("font")
+        layer = font.newLayer("L")
+        glyph = layer.newGlyph("X")
+        guideline = glyph.appendGuideline((1, 2), 90, "Test Guideline Glyph")
+        return guideline
+        
+
+    # ----
+    # repr
+    # ----
+
+    def test_reprContents(self):
+        guideline = self.getGuideline_generic()
+        value = guideline._reprContents()
+        self.assertIsInstance(value, list)
+        for i in value:
+            self.assertIsInstance(i, basestring)
+
+    def test_reprContents_noGlyph(self):
+        guideline, _ = self.objectGenerator("guideline")
+        value = guideline._reprContents()
+        self.assertIsInstance(value, list)
+        for i in value:
+            self.assertIsInstance(i, basestring)
 
     # --------
-    # Position
+    # Attributes
     # --------
 
     # x
 
-    def test_x_get(self):
+    def test_x_get_generic(self):
         guideline = self.getGuideline_generic()
         self.assertEqual(
             guideline.x,
             1
         )
 
-    def test_x_set_valid_zero(self):
+    def test_x_get_fontGuideline(self):
+        guideline = self.getGuideline_fontGuideline()
+        self.assertEqual(
+            guideline.x,
+            1
+        )
+
+    def test_x_get_glyphGuideline(self):
+        guideline = self.getGuideline_glyphGuideline()
+        self.assertEqual(
+            guideline.x,
+            1
+        )
+
+    def test_x_set_valid_zero_generic(self):
         guideline = self.getGuideline_generic()
+        guideline.x = 0
+        self.assertEqual(
+            guideline.x,
+            0
+        )
+
+    def test_x_set_valid_zero_fontGuideline(self):
+        guideline = self.getGuideline_fontGuideline()
+        guideline.x = 0
+        self.assertEqual(
+            guideline.x,
+            0
+        )
+
+    def test_x_set_valid_zero_glyphGuideline(self):
+        guideline = self.getGuideline_glyphGuideline()
         guideline.x = 0
         self.assertEqual(
             guideline.x,
@@ -66,6 +128,14 @@ class TestGuideline(unittest.TestCase):
             -1.1
         )
 
+    def test_x_set_valid_None(self):
+        guideline = self.getGuideline_generic()
+        guideline.x = None
+        self.assertEqual(
+            guideline.x,
+            0
+        )
+
     def test_x_set_invalid_string(self):
         guideline = self.getGuideline_generic()
         with self.assertRaises(TypeError):
@@ -73,15 +143,45 @@ class TestGuideline(unittest.TestCase):
 
     # y
 
-    def test_y_get(self):
+    def test_y_get_generic(self):
         guideline = self.getGuideline_generic()
         self.assertEqual(
             guideline.y,
             2
         )
 
-    def test_y_set_valid_zero(self):
+    def test_y_get_fontGuideline(self):
+        guideline = self.getGuideline_fontGuideline()
+        self.assertEqual(
+            guideline.y,
+            2
+        )
+
+    def test_y_get_glyphGuideline(self):
+        guideline = self.getGuideline_glyphGuideline()
+        self.assertEqual(
+            guideline.y,
+            2
+        )
+
+    def test_y_set_valid_zero_generic(self):
         guideline = self.getGuideline_generic()
+        guideline.y = 0
+        self.assertEqual(
+            guideline.y,
+            0
+        )
+
+    def test_y_set_valid_zero_fontGuideline(self):
+        guideline = self.getGuideline_fontGuideline()
+        guideline.y = 0
+        self.assertEqual(
+            guideline.y,
+            0
+        )
+
+    def test_y_set_valid_zero_glyphGuideline(self):
+        guideline = self.getGuideline_glyphGuideline()
         guideline.y = 0
         self.assertEqual(
             guideline.y,
@@ -120,6 +220,14 @@ class TestGuideline(unittest.TestCase):
             -1.1
         )
 
+    def test_y_set_valid_None(self):
+        guideline = self.getGuideline_generic()
+        guideline.y = None
+        self.assertEqual(
+            guideline.y,
+            0
+        )
+
     def test_y_set_invalid_string(self):
         guideline = self.getGuideline_generic()
         with self.assertRaises(TypeError):
@@ -127,15 +235,45 @@ class TestGuideline(unittest.TestCase):
 
     # angle
 
-    def test_angle_get(self):
+    def test_angle_get_generic(self):
         guideline = self.getGuideline_generic()
         self.assertEqual(
             guideline.angle,
             90
         )
 
-    def test_angle_set_valid_zero(self):
+    def test_angle_get_fontGuideline(self):
+        guideline = self.getGuideline_fontGuideline()
+        self.assertEqual(
+            guideline.angle,
+            90
+        )
+
+    def test_angle_get_glyphGuideline(self):
+        guideline = self.getGuideline_glyphGuideline()
+        self.assertEqual(
+            guideline.angle,
+            90
+        )
+
+    def test_angle_set_valid_zero_generic(self):
         guideline = self.getGuideline_generic()
+        guideline.angle = 0
+        self.assertEqual(
+            guideline.angle,
+            0
+        )
+
+    def test_angle_set_valid_zero_fontGuideline(self):
+        guideline = self.getGuideline_fontGuideline()
+        guideline.angle = 0
+        self.assertEqual(
+            guideline.angle,
+            0
+        )
+
+    def test_angle_set_valid_zero_glyphGuideline(self):
+        guideline = self.getGuideline_glyphGuideline()
         guideline.angle = 0
         self.assertEqual(
             guideline.angle,
@@ -185,6 +323,14 @@ class TestGuideline(unittest.TestCase):
     def test_angle_set_valid_negative_edge(self):
         guideline = self.getGuideline_generic()
         guideline.angle = -360
+        self.assertEqual(
+            guideline.angle,
+            0
+        )
+
+    def test_angle_set_valid_None(self):
+        guideline = self.getGuideline_generic()
+        guideline.angle = None
         self.assertEqual(
             guideline.angle,
             0
@@ -245,10 +391,6 @@ class TestGuideline(unittest.TestCase):
             0
         )
 
-    # --------------
-    # Identification
-    # --------------
-
     # index
 
     def getGuideline_index(self):
@@ -258,15 +400,36 @@ class TestGuideline(unittest.TestCase):
         glyph.appendGuideline((0, 0), 90, "guideline 2")
         return glyph
 
-    def test_index(self):
+    def test_get_index_noParent(self):
+        guideline, _ = self.objectGenerator("guideline")
+        self.assertIsNone(guideline.index)
+
+    def test_get_index(self):
         glyph = self.getGuideline_index()
         for i, guideline in enumerate(glyph.guidelines):
             self.assertEqual(guideline.index, i)
+            
+    def test_set_index_noParent(self):
+        guideline, _ = self.objectGenerator("guideline")
+        with self.assertRaises(FontPartsError):
+            guideline.index = 1
+
+    def test_set_index_positive(self):
+        glyph = self.getGuideline_index()
+        guideline = glyph.guidelines[0]
+        with self.assertRaises(FontPartsError):
+            guideline.index = 2
+
+    def test_set_index_negative(self):
+        glyph = self.getGuideline_index()
+        guideline = glyph.guidelines[1]
+        with self.assertRaises(FontPartsError):
+            guideline.index = -1
 
     # name
 
     def test_name_get_none(self):
-        guideline = self.getGuideline_generic()
+        guideline, _ = self.objectGenerator("guideline")
         self.assertIsNone(guideline.name)
 
     def test_name_set_valid(self):
@@ -364,9 +527,9 @@ class TestGuideline(unittest.TestCase):
         guideline._setIdentifier(identifier)
         self.assertEqual(guideline.identifier, identifier)
 
-    # --------------
-    # Transformation
-    # --------------
+    # -------
+    # Methods
+    # -------
 
     def getGuideline_copy(self):
         guideline = self.getGuideline_generic()
@@ -646,6 +809,80 @@ class TestGuideline(unittest.TestCase):
         self.assertTrue(
             isinstance(guideline_one, collections.Hashable)
         )
+
+    # -------
+    # Parents
+    # -------
+
+    def test_get_parent_font(self):
+        font, _ = self.objectGenerator("font")
+        layer = font.newLayer("L")
+        glyph = layer.newGlyph("X")
+        guideline = glyph.appendGuideline((0, 0), 90, "Test Guideline")
+        self.assertIsNotNone(guideline.font)
+        self.assertEqual(
+            guideline.font,
+            font
+        )
+
+    def test_get_parent_noFont(self):
+        layer, _ = self.objectGenerator("layer")
+        glyph = layer.newGlyph("X")
+        guideline = glyph.appendGuideline((0, 0), 90, "Test Guideline")
+        self.assertIsNone(guideline.font)
+
+    def test_get_parent_layer(self):
+        layer, _ = self.objectGenerator("layer")
+        glyph = layer.newGlyph("X")
+        guideline = glyph.appendGuideline((0, 0), 90, "Test Guideline")
+        self.assertIsNotNone(guideline.layer)
+        self.assertEqual(
+            guideline.layer,
+            layer
+        )
+
+    def test_get_parent_noLayer(self):
+        glyph, _ = self.objectGenerator("glyph")
+        guideline = glyph.appendGuideline((0, 0), 90, "Test Guideline")
+        self.assertIsNone(guideline.font)
+        self.assertIsNone(guideline.layer)
+
+    def test_get_parent_glyph(self):
+        glyph, _ = self.objectGenerator("glyph")
+        guideline = glyph.appendGuideline((0, 0), 90, "Test Guideline")
+        self.assertIsNotNone(guideline.glyph)
+        self.assertEqual(
+            guideline.glyph,
+            glyph
+        )
+
+    def test_get_parent_noGlyph(self):
+        guideline, _ = self.objectGenerator("guideline")
+        self.assertIsNone(guideline.font)
+        self.assertIsNone(guideline.layer)
+        self.assertIsNone(guideline.glyph)
+
+    def test_set_parent_glyph(self):
+        glyph, _ = self.objectGenerator("glyph")
+        guideline = self.getGuideline_generic()
+        guideline.glyph = glyph
+        self.assertIsNotNone(guideline.glyph)
+        self.assertEqual(
+            guideline.glyph,
+            glyph
+        )
+
+    def test_set_parent_glyph_none(self):
+        guideline, _ = self.objectGenerator("guideline")
+        guideline.glyph = None
+        self.assertIsNone(guideline.glyph)
+
+    def test_set_parent_glyph_exists(self):
+        glyph, _ = self.objectGenerator("glyph")
+        otherGlyph, _ = self.objectGenerator("glyph")
+        guideline = glyph.appendGuideline((0, 0), 90, "Test Guideline")
+        with self.assertRaises(AssertionError):
+            guideline.glyph = otherGlyph
 
     # --------
     # Equality


### PR DESCRIPTION
This branch adds more tests for the guideline object and makes one bug fix in fontShell — when adding a guideline to the font object the angle attribute wasn't set.

The coverage is still incomplete for three reasons —
- The isCompatible will be covered elsewhere
- The tests fail when checking for the guideline's parent objects and I can't track back to where this is happening, so I hope someone else can have a look.
- The attributes for ``x``, ``y`` and ``angle`` have extra checks built in to fill in the data when these come in as ``None`` but I haven't been able to find a way to test these (since setting the attribute to ``None`` will also convert the value to zero)

