### PR TITLE
Need the name of the layer

### DIFF
--- a/documentation/source/objects/font.rst
+++ b/documentation/source/objects/font.rst
@@ -134,7 +134,7 @@ Interacting with glyphs at the font level is a shortcut for interacting with gly
 
 Does the same thing as::
 
-	>>> glyph = font.getLayer(font.defaultLayer).newGlyph("A")
+	>>> glyph = font.getLayer(font.defaultLayer.name).newGlyph("A")
 
 .. automethod:: BaseFont.__len__
 .. automethod:: BaseFont.keys

--- a/documentation/source/objects/font.rst
+++ b/documentation/source/objects/font.rst
@@ -134,7 +134,7 @@ Interacting with glyphs at the font level is a shortcut for interacting with gly
 
 Does the same thing as::
 
-	>>> glyph = font.getLayer(font.defaultLayer.name).newGlyph("A")
+	>>> glyph = font.getLayer(font.defaultLayerName).newGlyph("A")
 
 .. automethod:: BaseFont.__len__
 .. automethod:: BaseFont.keys


### PR DESCRIPTION
If only the layer object is used, an error occurs.
```
TypeError: Layer names must be strings, not RLayer.
```
System used was Python 3.5.2 on Ubuntu Xenial 16.04 amd64