### PR TITLE
Explicitly set parents when adding a guideline to glyph or font.

### DIFF
--- a/Lib/fontParts/base/font.py
+++ b/Lib/fontParts/base/font.py
@@ -1230,7 +1230,9 @@ class BaseFont(
         if color is not None:
             color = normalizers.normalizeColor(color)
         identifier = normalizers.normalizeIdentifier(identifier)
-        return self._appendGuideline(position, angle, name=name, color=color, identifier=identifier)
+        guideline = self._appendGuideline(position, angle, name=name, color=color, identifier=identifier)
+        guideline.font = self
+        return guideline
 
     def _appendGuideline(self, position, angle, name=None, color=None, identifier=None, **kwargs):
         """

--- a/Lib/fontParts/base/glyph.py
+++ b/Lib/fontParts/base/glyph.py
@@ -1358,7 +1358,9 @@ class BaseGlyph(BaseObject,
         if color is not None:
             color = normalizers.normalizeColor(color)
         identifier = normalizers.normalizeIdentifier(identifier)
-        return self._appendGuideline(position, angle, name=name, color=color, identifier=identifier)
+        guideline = self._appendGuideline(position, angle, name=name, color=color, identifier=identifier)
+        guideline.glyph = self
+        return guideline
 
     def _appendGuideline(self, position, angle, name=None, color=None, identifier=None, **kwargs):
         """

--- a/Lib/fontParts/test/test_guideline.py
+++ b/Lib/fontParts/test/test_guideline.py
@@ -13,19 +13,19 @@ class TestGuideline(unittest.TestCase):
         guideline.angle = 90
         guideline.name = "Test Guideline"
         return guideline
-        
+
     def getGuideline_fontGuideline(self):
         font, _ = self.objectGenerator("font")
         guideline = font.appendGuideline((1, 2), 90, "Test Guideline Font")
         return guideline
-        
+
     def getGuideline_glyphGuideline(self):
         font, _ = self.objectGenerator("font")
         layer = font.newLayer("L")
         glyph = layer.newGlyph("X")
         guideline = glyph.appendGuideline((1, 2), 90, "Test Guideline Glyph")
         return guideline
-        
+
 
     # ----
     # repr
@@ -408,7 +408,7 @@ class TestGuideline(unittest.TestCase):
         glyph = self.getGuideline_index()
         for i, guideline in enumerate(glyph.guidelines):
             self.assertEqual(guideline.index, i)
-            
+
     def test_set_index_noParent(self):
         guideline, _ = self.objectGenerator("guideline")
         with self.assertRaises(FontPartsError):

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -1,3 +1,4 @@
+- 2018-06-08: Fixed a bug in setting the parents in appending a ``guideline`` to a ``Glyph`` or ``Font``.
 - 2018-05-30: Fixed a bug in both the base and fontshell implementations of ``groups.side1KerningGroups``.
 - 2018-05-30: Fixed a bug in both the base and fontshell implementations of ``groups.side2KerningGroups``.
 - 2018-05-30: Fixed a several bugs in ``BaseDict`` that would return values that hadn't been normalized.
@@ -8,7 +9,7 @@
 - 2018-05-30: ``layer.removeGlyph`` is now an alias for ``layer.__delitem__``.
 - 2018-05-30: ``font.insertGlyph`` is now an alias for ``font.__setitem__``.
 - 2018-05-30: ``layer.insertGlyph`` is now an alias for ``layer.__setitem__``.
-- 2018-05-30: ``font.appendGuideline`` now accepts a guideline object. 
+- 2018-05-30: ``font.appendGuideline`` now accepts a guideline object.
 - 2018-05-30: ``glyph.copy`` uses the new append API.
 - 2018-05-30: ``glyph.appendGlyph`` uses the new append API.
 - 2018-05-30: ``glyph.appendComponent`` now accepts a component object.


### PR DESCRIPTION
Also, automatic whitespace fixes.