### PR TITLE
Groups testing

### DIFF
--- a/Lib/fontParts/test/test_groups.py
+++ b/Lib/fontParts/test/test_groups.py
@@ -14,6 +14,17 @@ class TestGroups(unittest.TestCase):
         })
         return groups
 
+    # ----
+    # repr
+    # ----
+
+    def test_reprContents(self):
+        groups = self.getGroups_generic()
+        value = groups._reprContents()
+        self.assertIsInstance(value, list)
+        for i in value:
+            self.assertIsInstance(i, basestring)
+
     # ---
     # len
     # ---

--- a/Lib/fontParts/test/test_groups.py
+++ b/Lib/fontParts/test/test_groups.py
@@ -272,16 +272,63 @@ class TestGroups(unittest.TestCase):
     # --------------------- 
     # RoboFab Compatibility 
     # --------------------- 
-
-    ## in progress
     
-    # def test_remove(self):
-    #     groups = self.getGroups_generic()
-    #     groups.remove("group 1")
-    #     expected = {
-    #         "group 2": ["x", "y", "z"],
-    #         "group 3": [],
-    #         "group 4": ["A"]
-    #     }
-    #     print(groups)
-    #     self.assertEqual(groups, expected)
+    def test_remove(self):
+        groups = self.getGroups_generic()
+        groups.remove("group 2")
+        expected = {
+            "group 1": ("A", "B", "C"),
+            "group 3": (),
+            "group 4": ('A',)
+        }
+        self.assertEqual(groups.asDict(), expected)
+    
+    def test_remove_twice(self):
+        groups = self.getGroups_generic()
+        groups.remove("group 1")
+        with self.assertRaises(KeyError):
+            groups.remove("group 1")
+
+    def test_remove_nonexistant_group(self):
+        groups = self.getGroups_generic()
+        with self.assertRaises(KeyError):
+            groups.remove("group 7")
+
+    def test_asDict(self):
+        groups = self.getGroups_generic()
+        expected = {
+            "group 1": ("A", "B", "C"),
+            "group 2": ("x", "y", "z"),
+            "group 3": (),
+            "group 4": ('A',)
+        }
+        self.assertEqual(groups.asDict(), expected)
+
+    # -------------------
+    # Inherited Functions
+    # -------------------
+
+    def test_iter(self):
+        groups = self.getGroups_generic()
+        expected = ["group 1","group 2","group 3", "group 4"]
+
+        listOfGroups = []
+        for groupName in groups:
+            listOfGroups.append(groupName)
+
+        self.assertEqual(listOfGroups.sort(), expected.sort())
+
+    def test_iter_remove(self):
+        groups = self.getGroups_generic()
+        expected = []
+
+        for groupName in groups:
+            groups.remove(groupName)
+
+        self.assertEqual(groups.keys(), expected)
+
+
+    def test_values(self):
+        groups = self.getGroups_generic()
+        expected = [("A", "B", "C"), ("x", "y", "z"),(),('A',)]
+        self.assertEqual(groups.values().sort(), expected.sort())

--- a/Lib/fontParts/test/test_lib.py
+++ b/Lib/fontParts/test/test_lib.py
@@ -25,13 +25,6 @@ class TestLib(unittest.TestCase):
         for i in value:
             self.assertIsInstance(i, basestring)
 
-    def test_reprContents_noGlyph_noFont(self):
-        lib, _ = self.objectGenerator("lib")
-        value = lib._reprContents()
-        self.assertIsInstance(value, list)
-        for i in value:
-            self.assertIsInstance(i, basestring)
-
     # ---
     # len
     # ---

--- a/Lib/fontParts/test/test_lib.py
+++ b/Lib/fontParts/test/test_lib.py
@@ -45,6 +45,59 @@ class TestLib(unittest.TestCase):
         )
 
     # -------
+    # Parents
+    # -------
+
+    # Glyph
+
+    def test_get_parent_glyph(self):
+        glyph, _ = self.objectGenerator("glyph")
+        lib, _ = self.objectGenerator("lib")
+        lib.glyph = glyph
+        self.assertIsNotNone(lib.glyph)
+        self.assertEqual(
+            lib.glyph,
+            glyph
+        )
+
+    def test_get_parent_noGlyph(self):
+        lib, _ = self.objectGenerator("lib")
+        self.assertIsNone(lib.font)
+        self.assertIsNone(lib.layer)
+        self.assertIsNone(lib.glyph)
+
+    def test_set_parent_glyph(self):
+        glyph, _ = self.objectGenerator("glyph")
+        lib, _ = self.objectGenerator("lib")
+        lib.glyph = glyph
+        self.assertIsNotNone(lib.glyph)
+        self.assertEqual(
+            lib.glyph,
+            glyph
+        )
+
+    # Font
+
+    def test_get_parent_font(self):
+        font, _ = self.objectGenerator("font")
+        layer = font.newLayer("L")
+        glyph = layer.newGlyph("X")
+        lib, _ = self.objectGenerator("lib")
+        lib.glyph = glyph
+        self.assertIsNotNone(lib.font)
+        self.assertEqual(
+            lib.font,
+            font
+        )
+
+    def test_get_parent_noFont(self):
+        layer, _ = self.objectGenerator("layer")
+        glyph = layer.newGlyph("X")
+        lib, _ = self.objectGenerator("lib")
+        lib.glyph = glyph
+        self.assertIsNone(lib.font)
+
+    # -------
     # Queries
     # -------
 

--- a/Lib/fontParts/test/test_lib.py
+++ b/Lib/fontParts/test/test_lib.py
@@ -25,6 +25,13 @@ class TestLib(unittest.TestCase):
         for i in value:
             self.assertIsInstance(i, basestring)
 
+    def test_reprContents_noGlyph_noFont(self):
+        lib, _ = self.objectGenerator("lib")
+        value = lib._reprContents()
+        self.assertIsInstance(value, list)
+        for i in value:
+            self.assertIsInstance(i, basestring)
+
     # ---
     # len
     # ---

--- a/Lib/fontParts/test/test_lib.py
+++ b/Lib/fontParts/test/test_lib.py
@@ -14,6 +14,17 @@ class TestLib(unittest.TestCase):
         })
         return lib
 
+    # ----
+    # repr
+    # ----
+
+    def test_reprContents(self):
+        lib = self.getLib_generic()
+        value = lib._reprContents()
+        self.assertIsInstance(value, list)
+        for i in value:
+            self.assertIsInstance(i, basestring)
+
     # ---
     # len
     # ---


### PR DESCRIPTION
(I think?) complete testing for groups.py, except for `_get_side1KerningGroups` and `_get_side2KerningGroups`, which are overridden in fontshell groups.py