### PR TITLE
WIP: Improve anchor and component compatibility check

### DIFF
--- a/Lib/fontParts/base/compatibility.py
+++ b/Lib/fontParts/base/compatibility.py
@@ -277,7 +277,9 @@ class GlyphCompatibilityReporter(BaseCompatibilityReporter):
         self.contourCountDifference = False
         self.componentCountDifference = False
         self.guidelineCountDifference = False
+        self.anchorDifferences = []
         self.anchorCountDifference = False
+        self.anchorOrderDifference = False
         self.anchorsMissingFromGlyph1 = []
         self.anchorsMissingFromGlyph2 = []
         self.componentsMissingFromGlyph1 = []

--- a/Lib/fontParts/test/test_glyph.py
+++ b/Lib/fontParts/test/test_glyph.py
@@ -979,6 +979,81 @@ class TestGlyph(unittest.TestCase):
             ()
         )
 
+    # -------------
+    # Compatibility
+    # -------------
+
+    def test_isCompatible_anchors(self):
+        glyph1 = self.getGlyph_generic()
+        glyph1.clearAnchors()
+        glyph1.appendAnchor("a", (0, 0))
+        glyph1.appendAnchor("b", (0, 0))
+        glyph2 = self.getGlyph_generic()
+        glyph2.clearAnchors()
+        glyph2.appendAnchor("a", (0, 0))
+        glyph2.appendAnchor("b", (0, 0))
+        is_compatible, report = glyph1.isCompatible(glyph2)
+        self.assertTrue(is_compatible)
+        self.assertFalse(report.anchorDifferences)
+        self.assertFalse(report.anchorOrderDifference)
+        self.assertFalse(report.anchorCountDifference)
+        self.assertFalse(report.anchorsMissingFromGlyph1)
+        self.assertFalse(report.anchorsMissingFromGlyph2)
+
+    def test_isCompatible_anchors_order(self):
+        glyph1 = self.getGlyph_generic()
+        glyph1.clearAnchors()
+        glyph1.appendAnchor("a", (0, 0))
+        glyph1.appendAnchor("b", (0, 0))
+        glyph2 = self.getGlyph_generic()
+        glyph2.clearAnchors()
+        glyph2.appendAnchor("b", (0, 0))
+        glyph2.appendAnchor("a", (0, 0))
+        is_compatible, report = glyph1.isCompatible(glyph2)
+        self.assertTrue(is_compatible)
+        self.assertEqual(report.anchorDifferences, [(0, "a", "b"), (1, "b", "a")])
+        self.assertTrue(report.anchorOrderDifference)
+        self.assertFalse(report.anchorCountDifference)
+        self.assertFalse(report.anchorsMissingFromGlyph1)
+        self.assertFalse(report.anchorsMissingFromGlyph2)
+
+    def test_isCompatible_anchors_intersecting(self):
+        glyph1 = self.getGlyph_generic()
+        glyph1.clearAnchors()
+        glyph1.appendAnchor("a", (0, 0))
+        glyph1.appendAnchor("b", (0, 0))
+        glyph2 = self.getGlyph_generic()
+        glyph2.clearAnchors()
+        glyph2.appendAnchor("a", (0, 0))
+        glyph2.appendAnchor("b", (0, 0))
+        glyph2.appendAnchor("b", (0, 0))
+        is_compatible, report = glyph1.isCompatible(glyph2)
+        self.assertTrue(is_compatible)
+        self.assertEqual(report.anchorDifferences, [(2, None, "b")])
+        self.assertFalse(report.anchorOrderDifference)
+        self.assertTrue(report.anchorCountDifference)
+        self.assertEqual(report.anchorsMissingFromGlyph1, ["b"])
+        self.assertFalse(report.anchorsMissingFromGlyph2)
+
+    def test_isCompatible_anchors_disjoint(self):
+        glyph1 = self.getGlyph_generic()
+        glyph1.clearAnchors()
+        glyph1.appendAnchor("x", (0, 0))
+        glyph2 = self.getGlyph_generic()
+        glyph2.clearAnchors()
+        glyph2.appendAnchor("a", (0, 0))
+        glyph2.appendAnchor("a", (0, 0))
+        glyph2.appendAnchor("b", (0, 0))
+        is_compatible, report = glyph1.isCompatible(glyph2)
+        self.assertTrue(is_compatible)
+        self.assertEqual(
+            report.anchorDifferences, [(0, "x", "a"), (1, None, "a"), (2, None, "b")]
+        )
+        self.assertFalse(report.anchorOrderDifference)
+        self.assertTrue(report.anchorCountDifference)
+        self.assertEqual(report.anchorsMissingFromGlyph1, ["a", "a", "b"])
+        self.assertEqual(report.anchorsMissingFromGlyph2, ["x"])
+
     # ---
     # API
     # ---


### PR DESCRIPTION
This PR is motivated by https://github.com/robofab-developers/fontParts/issues/365 and https://github.com/robofab-developers/fontParts/issues/349.

The prototype implements the following changes:

- `GlyphCompatibilityReporter.anchorDifferences` holds all differences between anchors. E.g. comparing `["a", "b"]` to `["a", "a", "b"]` will result in a list of diffs of the form `(index, self_name, other_name)`: `[(1, "b", "a"), (2, None, "b")]`. Note how `None` is used if one list is longer than the other, as a stand-in for a missing anchor.
- `GlyphCompatibilityReporter.anchorOrderDifference` will be `True` if there are diffs, but the length of the anchor list is the same and both converted to sets are equal.
- `GlyphCompatibilityReporter.anchorsMissingFromGlyph(1|2)` will hold a list of anchor names that are missing, including duplicates, instead of `(name, index)` tuples. E.g. comparing `["a", "b"]` to `["a", "a", "b"]` will note that a duplicate `"a"` is missing in the first list.

If these changes to the API are ok, I can adapt the component check to work similarly.