### PR TITLE
Implement more precise component compatibility check

### DIFF
--- a/Lib/fontParts/base/compatibility.py
+++ b/Lib/fontParts/base/compatibility.py
@@ -103,6 +103,20 @@ class BaseCompatibilityReporter(object):
         return text
 
     @staticmethod
+    def reportOrderDifference(subObjectName,
+                              object1Name, object1Order,
+                              object2Name, object2Order):
+        text = ("{object1Name} has {subObjectName} ordered {object1Order} | "
+                "{object2Name} has {object2Order}").format(
+            subObjectName=subObjectName,
+            object1Name=object1Name,
+            object1Order=object1Order,
+            object2Name=object2Name,
+            object2Order=object2Order
+        )
+        return text
+
+    @staticmethod
     def reportDifferences(object1Name, subObjectName,
                           subObjectID, object2Name):
         text = ("{object1Name} contains {subObjectName} {subObjectID} "
@@ -349,6 +363,15 @@ class GlyphCompatibilityReporter(BaseCompatibilityReporter):
                 object1Count=len(glyph1.anchors),
                 object2Name=self.glyph2Name,
                 object2Count=len(glyph2.anchors)
+            )
+            report.append(self.formatWarningString(text))
+        elif self.anchorOrderDifference:
+            text = self.reportOrderDifference(
+                subObjectName="anchors",
+                object1Name=self.glyph1Name,
+                object1Order=[a.name for a in glyph1.anchors],
+                object2Name=self.glyph2Name,
+                object2Order=[a.name for a in glyph2.anchors]
             )
             report.append(self.formatWarningString(text))
         for name in self.anchorsMissingFromGlyph2:

--- a/Lib/fontParts/base/compatibility.py
+++ b/Lib/fontParts/base/compatibility.py
@@ -296,6 +296,8 @@ class GlyphCompatibilityReporter(BaseCompatibilityReporter):
         self.anchorOrderDifference = False
         self.anchorsMissingFromGlyph1 = []
         self.anchorsMissingFromGlyph2 = []
+        self.componentDifferences = []
+        self.componentOrderDifference = False
         self.componentsMissingFromGlyph1 = []
         self.componentsMissingFromGlyph2 = []
         self.guidelinesMissingFromGlyph1 = []
@@ -336,6 +338,15 @@ class GlyphCompatibilityReporter(BaseCompatibilityReporter):
                 object2Count=len(glyph2.components)
             )
             report.append(self.formatFatalString(text))
+        elif self.componentOrderDifference:
+            text = self.reportOrderDifference(
+                subObjectName="components",
+                object1Name=self.glyph1Name,
+                object1Order=[c.baseGlyph for c in glyph1.components],
+                object2Name=self.glyph2Name,
+                object2Order=[c.baseGlyph for c in glyph2.components]
+            )
+            report.append(self.formatWarningString(text))
         if len(self.componentsMissingFromGlyph2) != 0:
             for name in self.componentsMissingFromGlyph2:
                 text = self.reportDifferences(

--- a/Lib/fontParts/base/compatibility.py
+++ b/Lib/fontParts/base/compatibility.py
@@ -351,24 +351,22 @@ class GlyphCompatibilityReporter(BaseCompatibilityReporter):
                 object2Count=len(glyph2.anchors)
             )
             report.append(self.formatWarningString(text))
-        if len(self.anchorsMissingFromGlyph2) != 0:
-            for name in self.anchorsMissingFromGlyph2:
-                text = self.reportDifferences(
-                    object1Name=self.glyph1Name,
-                    subObjectName="anchor",
-                    subObjectID=name,
-                    object2Name=self.glyph2Name,
-                )
-                report.append(self.formatWarningString(text))
-        if len(self.anchorsMissingFromGlyph1) != 0:
-            for name in self.anchorsMissingFromGlyph1:
-                text = self.reportDifferences(
-                    object1Name=self.glyph2Name,
-                    subObjectName="anchor",
-                    subObjectID=name,
-                    object2Name=self.glyph1Name,
-                )
-                report.append(self.formatWarningString(text))
+        for name in self.anchorsMissingFromGlyph2:
+            text = self.reportDifferences(
+                object1Name=self.glyph1Name,
+                subObjectName="anchor",
+                subObjectID=name,
+                object2Name=self.glyph2Name,
+            )
+            report.append(self.formatWarningString(text))
+        for name in self.anchorsMissingFromGlyph1:
+            text = self.reportDifferences(
+                object1Name=self.glyph2Name,
+                subObjectName="anchor",
+                subObjectID=name,
+                object2Name=self.glyph1Name,
+            )
+            report.append(self.formatWarningString(text))
 
         # Guideline test
         if self.guidelineCountDifference:

--- a/Lib/fontParts/base/compatibility.py
+++ b/Lib/fontParts/base/compatibility.py
@@ -347,24 +347,22 @@ class GlyphCompatibilityReporter(BaseCompatibilityReporter):
                 object2Order=[c.baseGlyph for c in glyph2.components]
             )
             report.append(self.formatWarningString(text))
-        if len(self.componentsMissingFromGlyph2) != 0:
-            for name in self.componentsMissingFromGlyph2:
-                text = self.reportDifferences(
-                    object1Name=self.glyph1Name,
-                    subObjectName="component",
-                    subObjectID=name,
-                    object2Name=self.glyph2Name,
-                )
-                report.append(self.formatWarningString(text))
-        if len(self.componentsMissingFromGlyph1) != 0:
-            for name in self.componentsMissingFromGlyph1:
-                text = self.reportDifferences(
-                    object1Name=self.glyph2Name,
-                    subObjectName="component",
-                    subObjectID=name,
-                    object2Name=self.glyph1Name,
-                )
-                report.append(self.formatWarningString(text))
+        for name in self.componentsMissingFromGlyph2:
+            text = self.reportDifferences(
+                object1Name=self.glyph1Name,
+                subObjectName="component",
+                subObjectID=name,
+                object2Name=self.glyph2Name,
+            )
+            report.append(self.formatWarningString(text))
+        for name in self.componentsMissingFromGlyph1:
+            text = self.reportDifferences(
+                object1Name=self.glyph2Name,
+                subObjectName="component",
+                subObjectID=name,
+                object2Name=self.glyph1Name,
+            )
+            report.append(self.formatWarningString(text))
 
         # Anchor test
         if self.anchorCountDifference:
@@ -412,24 +410,22 @@ class GlyphCompatibilityReporter(BaseCompatibilityReporter):
                 object2Count=len(glyph2.guidelines)
             )
             report.append(self.formatWarningString(text))
-        if len(self.guidelinesMissingFromGlyph2) != 0:
-            for name in self.guidelinesMissingFromGlyph2:
-                text = self.reportDifferences(
-                    object1Name=self.glyph1Name,
-                    subObjectName="guideline",
-                    subObjectID=name,
-                    object2Name=self.glyph2Name,
-                )
-                report.append(self.formatWarningString(text))
-        if len(self.guidelinesMissingFromGlyph1) != 0:
-            for name in self.guidelinesMissingFromGlyph1:
-                text = self.reportDifferences(
-                    object1Name=self.glyph2Name,
-                    subObjectName="guideline",
-                    subObjectID=name,
-                    object2Name=self.glyph1Name,
-                )
-                report.append(self.formatWarningString(text))
+        for name in self.guidelinesMissingFromGlyph2:
+            text = self.reportDifferences(
+                object1Name=self.glyph1Name,
+                subObjectName="guideline",
+                subObjectID=name,
+                object2Name=self.glyph2Name,
+            )
+            report.append(self.formatWarningString(text))
+        for name in self.guidelinesMissingFromGlyph1:
+            text = self.reportDifferences(
+                object1Name=self.glyph2Name,
+                subObjectName="guideline",
+                subObjectID=name,
+                object2Name=self.glyph1Name,
+            )
+            report.append(self.formatWarningString(text))
 
         if report or showOK:
             report.insert(0, self.title)

--- a/Lib/fontParts/test/test_glyph.py
+++ b/Lib/fontParts/test/test_glyph.py
@@ -1054,6 +1054,84 @@ class TestGlyph(unittest.TestCase):
         self.assertEqual(report.anchorsMissingFromGlyph1, ["a", "a", "b"])
         self.assertEqual(report.anchorsMissingFromGlyph2, ["x"])
 
+    def test_isCompatible_components(self):
+        glyph1, _ = self.objectGenerator("glyph")
+        glyph1.appendComponent("a")
+        glyph1.appendComponent("b")
+        glyph2, _ = self.objectGenerator("glyph")
+        glyph2.appendComponent("a")
+        glyph2.appendComponent("b")
+        is_compatible, report = glyph1.isCompatible(glyph2)
+        self.assertTrue(is_compatible)
+        self.assertFalse(report.componentDifferences)
+        self.assertFalse(report.componentOrderDifference)
+        self.assertFalse(report.componentCountDifference)
+        self.assertFalse(report.componentsMissingFromGlyph1)
+        self.assertFalse(report.componentsMissingFromGlyph2)
+
+    def test_isCompatible_components_order(self):
+        glyph1, _ = self.objectGenerator("glyph")
+        glyph1.appendComponent("a")
+        glyph1.appendComponent("b")
+        glyph2, _ = self.objectGenerator("glyph")
+        glyph2.appendComponent("b")
+        glyph2.appendComponent("a")
+        is_compatible, report = glyph1.isCompatible(glyph2)
+        self.assertTrue(is_compatible)
+        self.assertEqual(report.componentDifferences, [(0, "a", "b"), (1, "b", "a")])
+        self.assertTrue(report.componentOrderDifference)
+        self.assertFalse(report.componentCountDifference)
+        self.assertFalse(report.componentsMissingFromGlyph1)
+        self.assertFalse(report.componentsMissingFromGlyph2)
+
+    def test_isCompatible_components_intersecting(self):
+        glyph1, _ = self.objectGenerator("glyph")
+        glyph1.appendComponent("a")
+        glyph1.appendComponent("b")
+        glyph2, _ = self.objectGenerator("glyph")
+        glyph2.appendComponent("a")
+        glyph2.appendComponent("b")
+        glyph2.appendComponent("b")
+        is_compatible, report = glyph1.isCompatible(glyph2)
+        self.assertFalse(is_compatible)
+        self.assertEqual(report.componentDifferences, [(2, None, "b")])
+        self.assertFalse(report.componentOrderDifference)
+        self.assertTrue(report.componentCountDifference)
+        self.assertEqual(report.componentsMissingFromGlyph1, ["b"])
+        self.assertFalse(report.componentsMissingFromGlyph2)
+
+    def test_isCompatible_components_disjoint(self):
+        glyph1, _ = self.objectGenerator("glyph")
+        glyph1.appendComponent("x")
+        glyph2, _ = self.objectGenerator("glyph")
+        glyph2.appendComponent("a")
+        glyph2.appendComponent("a")
+        glyph2.appendComponent("b")
+        is_compatible, report = glyph1.isCompatible(glyph2)
+        self.assertFalse(is_compatible)
+        self.assertEqual(
+            report.componentDifferences, [(0, "x", "a"), (1, None, "a"), (2, None, "b")]
+        )
+        self.assertFalse(report.componentOrderDifference)
+        self.assertTrue(report.componentCountDifference)
+        self.assertEqual(report.componentsMissingFromGlyph1, ["a", "a", "b"])
+        self.assertEqual(report.componentsMissingFromGlyph2, ["x"])
+
+    def test_isCompatible_components_disjoint_equal_size(self):
+        glyph1, _ = self.objectGenerator("glyph")
+        glyph1.appendComponent("x")
+        glyph1.appendComponent("y")
+        glyph2, _ = self.objectGenerator("glyph")
+        glyph2.appendComponent("a")
+        glyph2.appendComponent("b")
+        is_compatible, report = glyph1.isCompatible(glyph2)
+        self.assertFalse(is_compatible)
+        self.assertEqual(report.componentDifferences, [(0, "x", "a"), (1, "y", "b")])
+        self.assertFalse(report.componentOrderDifference)
+        self.assertFalse(report.componentCountDifference)
+        self.assertEqual(report.componentsMissingFromGlyph1, ["a", "b"])
+        self.assertEqual(report.componentsMissingFromGlyph2, ["x", "y"])
+
     # ---
     # API
     # ---


### PR DESCRIPTION
Continuation of https://github.com/robofab-developers/fontParts/pull/368.

I made component mismatches a fatal error here, they were warnings before. I can imagine anchors not being strictly needed for interpolation, but components?